### PR TITLE
JBIDE-17019: add m2eclipse-egit

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -101,6 +101,10 @@
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
       <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201212120353"/>
     </location>
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201401060023/"/>
+      <unit id="org.sonatype.m2e.egit.feature.feature.group" version="0.14.0.201401060023"/>
+    </location>
 
     <!-- Only in JBDS: 
     m2e-extension m2e.jdt.feature is only in JBDS BYOE / installer (unlike maven.jdt.feature, which is part of jbosstools-central and is therefore in BOTH JBT & JBDS update sites) 

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -98,6 +98,10 @@
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
       <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201212120353"/>
     </location>
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201401060023/"/>
+      <unit id="org.sonatype.m2e.egit.feature.feature.group" version="0.14.0.201401060023"/>
+    </location>
 
     <!-- Eclipse -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">


### PR DESCRIPTION
We want m2eclipse-egit to be
- installed by default with JBT => so goes to JBT TP
- part of JBDS delivery => so goes to JBDS TP
