### PR TITLE
[JBIDE-19002] Update Tern.java in target platform to latest one

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -400,13 +400,13 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/0.6.0.201409231610-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/0.8.0.201501132311-SNAPSHOT/"/>
       <unit id="minimal-json" version="0.9.1"/>
-      <unit id="tern-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern-jsdt-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern-server-nodejs-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern.eclipse.ide.tools.feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern.eclipse.ide.server.nodejs.embed.feature.group" version="0.6.0.201409231610"/>
+      <unit id="tern-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern-jsdt-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern-server-nodejs-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern.eclipse.ide.tools.feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern.eclipse.ide.server.nodejs.embed.feature.group" version="0.8.0.201501132311"/>
     </location>
       
     <!-- Only in JBDS (shipped in installer): TestNG -->

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -430,13 +430,13 @@
     <!-- NOTE's Note: Since Early Access site reference this target, it's probably not that necessary to duplicate it-->
     <!-- TODO: update jbtearlyaccess-multiple.target too -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/0.6.0.201409231610-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/0.8.0.201501132311-SNAPSHOT/"/>
       <unit id="minimal-json" version="0.9.1"/>
-      <unit id="tern-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern-jsdt-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern-server-nodejs-feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern.eclipse.ide.tools.feature.feature.group" version="0.6.0.201409231610"/>
-      <unit id="tern.eclipse.ide.server.nodejs.embed.feature.group" version="0.6.0.201409231610"/>
+      <unit id="tern-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern-jsdt-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern-server-nodejs-feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern.eclipse.ide.tools.feature.feature.group" version="0.8.0.201501132311"/>
+      <unit id="tern.eclipse.ide.server.nodejs.embed.feature.group" version="0.8.0.201501132311"/>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>


### PR DESCRIPTION
Fix includes latest tern.java nightly build 0.8.0.201501132311-SNAPSHOT