### PR TITLE
[JBIDE-19776] Create and use Mars RC2 target-platform

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -323,6 +323,14 @@
       <unit id="org.eclipse.jetty.proxy" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.rewrite" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.servlets" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.util" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.server" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.http" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.io" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.security" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.api" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.common" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.server" version="9.2.10.v20150310"/>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -320,6 +320,14 @@
       <unit id="org.eclipse.jetty.proxy" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.rewrite" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.servlets" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.util" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.server" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.http" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.io" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.2.10.v20150310"/>
+      <unit id="org.eclipse.jetty.security" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.api" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.common" version="9.2.10.v20150310"/>
       <unit id="org.eclipse.jetty.websocket.server" version="9.2.10.v20150310"/>


### PR DESCRIPTION
Adding the Jetty 9 bundles in versoin 9.2.10 that are missing for LiveReload
(LiveReload would use a mix of 9.2.9 and 9.2.10 bundles, which causes errors because of
some  java.lang.NoClassDefFoundError: org/eclipse/jetty/util/thread/SpinLock)