### PR TITLE
JBIDE-21651
mirror changes to 4.52.x branch...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbdevstudiotarget-4.50.2.Beta2-SNAPSHOT">
+<target includeMode="feature" name="jbdevstudiotarget-4.50.2.CR1-SNAPSHOT">
   <!-- Pro tip: to convert
       from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
     to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>

--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -16,6 +16,11 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/R20151118145958/"/>
+      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/R20150519210750/"/>
 
       <!-- for these IUs we need multiple versions -->
@@ -48,9 +53,6 @@
       <unit id="org.apache.httpcomponents.httpclient" version="4.3.6.v201411290715"/>
       <unit id="org.apache.httpcomponents.httpcore" version="4.3.3.v201411290715"/>
       <unit id="org.apache.axis" version="1.4.0.v201411182030"/>
-      <unit id="org.apache.commons.io" version="2.0.1.v201105210651"/>
-      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.commons.codec" version="1.3.0.v201101211617"/>
       <unit id="javax.ejb" version="3.1.1.v201204261316"/>
       <unit id="javax.transaction" version="1.1.1.v201105210645"/>
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
@@ -91,8 +93,8 @@
 
     <!-- m2e family, not included in SimRel site; see also Central TP for more -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.1.1-2014-11-26_15-11-10-H37/"/>
-      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.1.1.201411262015"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.2.0-2016-01-25_16-03-44-H45/"/>
+      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.2.0.201601252104"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
@@ -113,12 +115,18 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.0.201502101659"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.6.1.20150625-2338/"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.1.20150625-2338"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.6.1.20150625-2338"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.6.3.20160209-1446/"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.3.20160209-1446"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.6.3.20160209-1446"/>
     </location>
 
     <!-- SimRel -->
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/20160217-1705-2.RC4/"/> 
+
+      <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160217-0435"/>
+    </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/201506181000-SR0/"/>
 
@@ -222,8 +230,6 @@
 
       <!-- needed for JBoss Central -->
       <unit id="com.sun.syndication" version="0.9.0.v200803061811"/>
-      <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.0.0.v20150617-0732"/>
       <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
 
       <unit id="org.eclipse.ui" version="3.107.0.v20150507-1945"/>
@@ -315,10 +321,10 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/1.0.0.201506011405/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/1.0.1.201509081531/"/>
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.launchbar.core" version="1.0.0.201506011405"/>
-      <unit id="org.eclipse.launchbar.ui" version="1.0.0.201506011405"/>
+      <unit id="org.eclipse.launchbar.core" version="1.0.1.201509081531"/>
+      <unit id="org.eclipse.launchbar.ui" version="1.0.1.201509081531"/>
     </location>
 
     <!-- TM and RSE are in Luna site but this way we get sources too -->
@@ -444,8 +450,8 @@
     
     <!-- Easymport -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151120-0655-SNAPSHOT/"/>
-      <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151120-0655"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151123-1229-SNAPSHOT/"/>
+      <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151123-1229"/>
       <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20150908-1034"/>
       <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20150908-1034"/>
     </location>
@@ -466,11 +472,11 @@
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201601192048/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.0.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201601192048"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201602162146/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201602162146"/>
       <unit id="com.spotify.docker.client" version="3.1.10.v20151113-2033"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>

--- a/jbdevstudio/multiple/pom.xml
+++ b/jbdevstudio/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-multiple</artifactId>
 	<name>JBDS Multiple (Composite) Target Platform</name>

--- a/jbdevstudio/pom.xml
+++ b/jbdevstudio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbdevstudio</artifactId>

--- a/jbdevstudio/unified/pom.xml
+++ b/jbdevstudio/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-unified</artifactId>
 	<name>JBDS Unified (Aggregate) Target Platform</name>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.50.2.Beta2-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.50.2.CR1-SNAPSHOT">
   <!-- Pro tip: to convert
       from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
     to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -16,6 +16,11 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/R20151118145958/"/>
+      <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/R20150519210750/"/>
 
       <!-- for these IUs we need multiple versions -->
@@ -48,9 +53,6 @@
       <unit id="org.apache.httpcomponents.httpclient" version="4.3.6.v201411290715"/>
       <unit id="org.apache.httpcomponents.httpcore" version="4.3.3.v201411290715"/>
       <unit id="org.apache.axis" version="1.4.0.v201411182030"/>
-      <unit id="org.apache.commons.io" version="2.0.1.v201105210651"/>
-      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.commons.codec" version="1.3.0.v201101211617"/>
       <unit id="javax.ejb" version="3.1.1.v201204261316"/>
       <unit id="javax.transaction" version="1.1.1.v201105210645"/>
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
@@ -94,8 +96,8 @@
 
     <!-- m2e family, not included in SimRel site; see also Central TP for more -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.1.1-2014-11-26_15-11-10-H37/"/>
-      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.1.1.201411262015"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.2.0-2016-01-25_16-03-44-H45/"/>
+      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.2.0.201601252104"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
@@ -111,12 +113,18 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.0.201502101659"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.6.1.20150625-2338/"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.1.20150625-2338"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.6.1.20150625-2338"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.6.3.20160209-1446/"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.6.3.20160209-1446"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.6.3.20160209-1446"/>
     </location>
 
     <!-- SimRel -->
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/20160217-1705-2.RC4/"/> 
+
+      <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160217-0435"/>
+    </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/201506181000-SR0/"/>
 
@@ -220,8 +228,6 @@
 
       <!-- needed for JBoss Central -->
       <unit id="com.sun.syndication" version="0.9.0.v200803061811"/>
-      <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.0.0.v20150617-0732"/>
       <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
 
       <unit id="org.eclipse.ui" version="3.107.0.v20150507-1945"/>
@@ -327,10 +333,10 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/1.0.0.201506011405/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/1.0.1.201509081531/"/>
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.launchbar.core" version="1.0.0.201506011405"/>
-      <unit id="org.eclipse.launchbar.ui" version="1.0.0.201506011405"/>
+      <unit id="org.eclipse.launchbar.core" version="1.0.1.201509081531"/>
+      <unit id="org.eclipse.launchbar.ui" version="1.0.1.201509081531"/>
     </location>
 
     <!-- TM and RSE are in Luna site but this way we get sources too -->
@@ -487,8 +493,8 @@
     
     <!-- Easymport -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151120-0655-SNAPSHOT/"/>
-      <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151120-0655"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151123-1229-SNAPSHOT/"/>
+      <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151123-1229"/>
       <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20150908-1034"/>
       <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20150908-1034"/>
     </location>
@@ -503,11 +509,11 @@
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201601192048/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.0.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201601192048"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201602162146/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201602162146"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201602162146"/>
       <unit id="com.spotify.docker.client" version="3.1.10.v20151113-2033"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.50.2.Beta2-SNAPSHOT</version>
+		<version>4.50.2.CR1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.50.2.Beta2-SNAPSHOT</version>
+	<version>4.50.2.CR1-SNAPSHOT</version>
 	<name>JBoss Tools + JBDS Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
JBIDE-21651
mirror changes to 4.52.x branch into 4.50.x TP: commons.io 2.2
m2e.apt 1.2
m2e 1.6.3
aeri 1.0.0.v20150617-0732 -> 1.100.0.v20160217-0435
launchbar 1.0.1
e4.ui.importer 0.2
docker tools 1.2.1 RC4