### PR TITLE
JBIDE-21386 remove explicitly included old...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -97,7 +97,7 @@
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201509090157/"/>
       <unit id="org.sonatype.m2e.egit.feature.feature.group" version="0.14.0.201509090157"/>
     </location>
-    <!-- JBDS-3032 move m2e.jdt from Central to JBDS TP -->
+    <!-- Only in JBDS: JBDS-3032 move m2e.jdt from Central to JBDS TP -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-jdt-compiler/"/>
       <unit id="org.jboss.tools.m2e.jdt.feature.feature.group" version="1.0.1.201209200903"/>
@@ -120,7 +120,6 @@
       <!-- m2e -->
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20151215-0013"/>
       <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20151215-0013"/>
-
       <!-- m2e-wtp -->
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.0.20151111-2338"/>
       <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.3.0.20151111-2338"/>
@@ -181,7 +180,6 @@
       <unit id="org.eclipse.help.feature.group" version="2.1.1.v20151209-2300"/>
 
       <!-- DTP -->
-      <!-- removed from Neon M3 <unit id="org.eclipse.core.runtime.compatibility" version="3.2.300.v20150423-0821"/> -->
       <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.13.0.201512142037"/>
       <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.13.0.201512142037"/>
       <unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.13.0.201512142037"/>
@@ -244,8 +242,8 @@
       <unit id="org.eclipse.ui.ide" version="3.12.0.v20151202-1450"/>
       <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20151209-0723"/>
       <unit id="org.eclipse.jface.text" version="3.11.0.v20151208-1534"/>
-      <!-- have to manually update this one if more than one version exists in Kepler mirror -->
-      <unit id="org.eclipse.osgi" version="3.10.200.v20151207-2221"/>
+      <!-- have to manually update this one if more than one version exists in SimRel mirror -->
+      <!-- <unit id="org.eclipse.osgi" version="3.11.0.v20160121-2005"/> -->
       <unit id="org.eclipse.core.filesystem" version="1.6.0.v20151007-1725"/>
       <unit id="org.eclipse.ui.forms" version="3.7.0.v20151202-1950"/>
       <unit id="org.eclipse.ui.editors" version="3.10.0.v20151201-1259"/>
@@ -461,7 +459,7 @@
     and o.e.birt.feature [JBT only]
     -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.6.0.v201512160111/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.6.0.v201602022206/"/>
       <!-- removed from Neon M3 but available in birt mirror -->
       <unit id="org.eclipse.core.runtime.compatibility" version="3.2.300.v20150423-0821"/>
     </location>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -79,7 +79,7 @@
 
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
         <repository location="https://repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/update.site/1.3.0.Final/update.site-1.3.0.Final.zip-unzip/"/>
-	<!-- Test dependencies -->
+	<!-- Only in JBT: Test dependencies -->
         <unit id="org.jboss.tools.locus.mockito" version="1.9.5.v20131024-0922"/>
         <unit id="org.assertj.core" version="2.1.0"/>
 	<!-- For Jetty websocket 9.2.13 -->
@@ -106,7 +106,7 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.0.201502101659"/>
     </location>
     <!--<location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160202-2119//"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160202-2119/"/>
       <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20151110-2248"/>
       <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20151110-2248"/>
     </location>-->
@@ -240,8 +240,8 @@
       <unit id="org.eclipse.ui.ide" version="3.12.0.v20151202-1450"/>
       <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20151209-0723"/>
       <unit id="org.eclipse.jface.text" version="3.11.0.v20151208-1534"/>
-      <!-- have to manually update this one if more than one version exists in Kepler mirror -->
-      <unit id="org.eclipse.osgi" version="3.10.200.v20151207-2221"/>
+      <!-- have to manually update this one if more than one version exists in SimRel mirror -->
+      <!-- <unit id="org.eclipse.osgi" version="3.11.0.v20160121-2005"/> -->
       <unit id="org.eclipse.core.filesystem" version="1.6.0.v20151007-1725"/>
       <unit id="org.eclipse.ui.forms" version="3.7.0.v20151202-1950"/>
       <unit id="org.eclipse.ui.editors" version="3.10.0.v20151201-1259"/>
@@ -278,7 +278,7 @@
       <unit id="org.eclipse.jgit.feature.group" version="4.2.0.201512141825-rc1"/>
       <unit id="org.eclipse.egit.feature.group" version="4.2.0.201512141825-rc1"/>
 
-      <!-- JBIDE-16794 Apache Batik 1.6.0 is required by BIRT, but BIRT site only contains 1.7.0 -->
+      <!-- Only in JBT: JBIDE-16794 Apache Batik 1.6.0 is required by BIRT, but BIRT site only contains 1.7.0 -->
       <unit id="org.apache.batik.bridge" version="1.6.0.v201011041432"/>
       <unit id="org.apache.batik.css" version="1.6.0.v201011041432"/>
       <unit id="org.apache.batik.dom" version="1.6.1.v201505192100"/>
@@ -377,7 +377,7 @@
       <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.5.v20151012"/>
       <unit id="org.eclipse.jetty.xml" version="9.3.5.v20151012"/>
 
-      <!-- Required by birt -->
+      <!-- Only in JBT: Required by birt -->
       <unit id="org.eclipse.jetty.osgi.boot" version="9.3.5.v20151012"/>
       <unit id="org.eclipse.jetty.deploy" version="9.3.5.v20151012"/>
       <unit id="org.eclipse.jetty.annotations" version="9.3.5.v20151012"/>


### PR DESCRIPTION
JBIDE-21386 remove explicitly included old version of org.eclipse.osgi 3.10.200; should just include latest (3.11.0.v20160121-2005) to avoid install problems; also update comments and fix typos/inconsistencies between JBT and JBDS TPs