### PR TITLE
JBIDE-22200 move up to Neon.0.M7 + 8 more changes

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -215,6 +215,7 @@
 
       <!-- Recommenders for Java (and deps) -->
       <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
+      <unit id="org.eclipse.recommenders.snipmatch.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
       <unit id="org.eclipse.aether.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.file.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.http.feature.feature.group" version="1.0.1.v20141111"/>
@@ -391,10 +392,6 @@
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M7-20160503010110/"/>
-
-      <!-- JBIDE-21171 new for Neon M4 -->
-      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
-
       <unit id="org.eclipse.jst.jee" version="1.0.700.v201404092004"/>
       <unit id="org.eclipse.jst.jee.web" version="1.0.500.v201404021628"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
@@ -434,6 +431,9 @@
       <unit id="org.eclipse.wst.common.fproj.feature.group" version="3.7.0.v201505072140"/>
       <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.0.0.v201604300029"/>
+      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
+      <unit id="org.eclipse.wst.json_ui.feature.feature.group" version="1.0.0.v201604280217"/>
+      <unit id="org.eclipse.wst.json_core.feature.feature.group" version="1.0.0.v201604280217"/>
       <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.403.v201508132126"/>
       <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201603031514"/>
       <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201604062105"/>
@@ -490,6 +490,7 @@
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.0.0.201605032008/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.core" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.0.201605032008"/>

--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -10,28 +10,28 @@
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20151204220443/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20160501200945/"/>
 
       <!-- for these IUs we need multiple versions -->
       <unit id="javax.wsdl" version="1.6.2.v201012040545"/>
       <unit id="javax.wsdl" version="1.5.1.v201012040544"/>
       <unit id="org.jdom" version="1.1.1.v201101151400"/>
-      <unit id="org.jdom" version="1.0.0.v201005080400"/>
+      <unit id="org.jdom" version="1.1.1.v201101151400"/>
       <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
       <unit id="javax.wsdl" version="1.6.2.v201012040545"/>
       <unit id="javax.wsdl" version="1.5.1.v201012040544"/>
       <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
-      <unit id="javax.xml.bind" version="2.1.9.v201005080401"/>
+      <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
       <unit id="javax.xml.soap" version="1.3.0.v201105210645"/>
       <unit id="javax.xml.soap" version="1.2.0.v201005080501"/>
       <unit id="org.apache.commons.collections" version="3.2.2.v201511171945"/>
       <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
       <unit id="org.apache.commons.logging" version="1.0.4.v201101211617"/>
-      <unit id="org.apache.lucene" version="2.9.1.v201101211721"/>
-      <unit id="org.apache.lucene" version="1.9.1.v201101211617"/>
+      <unit id="org.apache.lucene" version="3.5.0.v20120725-1805"/>
       <unit id="org.apache.lucene.core" version="3.5.0.v20120725-1805"/>
-      <unit id="org.apache.lucene.core" version="2.9.1.v201101211721"/>
+      <unit id="org.apache.lucene.misc" version="3.5.0.v20120725-1805"/>
+      <unit id="org.apache.lucene.queries" version="3.5.0.v20120725-1805"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
 
       <!-- Orbit bundles -->
@@ -42,7 +42,7 @@
       <unit id="org.apache.axis" version="1.4.0.v201411182030"/>
       <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
       <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.commons.codec" version="1.3.0.v201101211617"/>
+      <unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
       <unit id="javax.ejb" version="3.1.1.v201204261316"/>
       <unit id="javax.transaction" version="1.1.1.v201105210645"/>
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
@@ -51,7 +51,7 @@
       <unit id="ch.qos.logback.classic" version="1.0.7.v20121108-1250"/>
       <unit id="ch.qos.logback.core" version="1.0.7.v20121108-1250"/>
       <!-- Needed by jbosstools-aerogear -->
-      <unit id="com.google.gson" version="2.1.0.v201303041604"/>
+      <unit id="com.google.gson" version="2.2.4.v201311231704"/>
 
       <!-- Needed for Mylyn/Bugzilla -->
       <unit id="org.apache.xmlrpc" version="3.0.0.v20100427-1100"/>
@@ -69,7 +69,7 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/1.1.0.201511082254/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/1.2.0.201604271713/"/>
       <!-- Required by FeedHenry module -->
       <unit id="minimal-json" version="0.9.4"/>
     </location>
@@ -87,8 +87,8 @@
       <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.2.0.201601252104"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
-      <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201212120353"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e-buildhelper/0.15.0.201405280027/"/>
+      <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201405280027"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201509090157/"/>
@@ -105,19 +105,19 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.0.201502101659"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160202-2119/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160504-0322/"/>
       <!--unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20151110-2248"/>
       <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20151110-2248"/-->
-      <unit id="org.eclipse.m2e.importer" version="1.7.0.20160202-2119"/>
+      <unit id="org.eclipse.m2e.importer" version="1.7.0.20160504-0322"/>
     </location>
 
     <!-- SimRel -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/neon/201602051000-M5/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/neon/201605061000-M7/"/>
 
       <!-- m2e -->
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160202-2119"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20160202-2119"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160504-0322"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20160504-0322"/>
       <!-- m2e-wtp -->
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.0.20151111-2338"/>
       <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.3.0.20151111-2338"/>
@@ -126,95 +126,95 @@
 
       <!-- p2.discovery -->
       <unit id="org.eclipse.equinox.p2.discovery.compatibility" version="1.0.200.v20131211-1531"/>
-      <unit id="org.eclipse.equinox.p2.discovery" version="1.0.300.v20131210-1027"/>
+      <unit id="org.eclipse.equinox.p2.discovery" version="1.0.300.v20160419-0834"/>
       <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.0.100.v20150907-2149"/>
 
       <!-- ECF -->
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.2.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.12.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.12.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
       <unit id="org.eclipse.equinox.concurrent" version="1.1.0.v20130327-1442"/>
 
       <!-- EMF, XSD -->
-      <unit id="org.eclipse.emf.workspace.feature.group" version="1.10.0.201512152038"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201512142118"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="1.10.0.201512152038"/>
-      <unit id="org.eclipse.emf.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.codegen.feature.group" version="2.11.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.databinding.feature.group" version="1.4.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.11.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.edit.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.edit.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.editor.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.mapping.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.feature.group" version="2.12.0.v20160201-0859"/>
+      <unit id="org.eclipse.emf.workspace.feature.group" version="1.10.0.201605031913"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201605030103"/>
+      <unit id="org.eclipse.emf.transaction.feature.group" version="1.10.0.201605031913"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.codegen.feature.group" version="2.11.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.databinding.feature.group" version="1.4.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.edit.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.edit.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.editor.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.mapping.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.feature.group" version="2.12.0.v20160429-0808"/>
 
       <!-- GEF, Draw2D -->
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201602010304"/>
-      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201602010304"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201605020204"/>
+      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201605020204"/>
 
       <!-- Platform: CVS, JDT, RCP, PDE, Equinox, Help -->
-      <unit id="com.ibm.icu.base" version="54.1.1.v201511091919"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160128-2000"/>
-      <unit id="org.eclipse.cvs.feature.group" version="1.4.300.v20160128-2000"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.12.0.v20160128-2000"/>
-      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.4.0.v20160125-0953"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20160128-1437"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.300.v20150907-2149"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.200.v20160128-1810"/>
-      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.3.0.v20160115-0911"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160128-2000"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.12.0.v20160128-2000"/>
-      <unit id="org.eclipse.help.feature.group" version="2.2.0.v20160128-2000"/>
+      <unit id="com.ibm.icu.base" version="56.1.0.v201601250100"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160428-0800"/>
+      <unit id="org.eclipse.cvs.feature.group" version="1.4.300.v20160428-0800"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.12.0.v20160428-0800"/>
+      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.4.0.v20160427-2120"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20160427-1608"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.400.v20160419-0834"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.200.v20160427-2220"/>
+      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.3.0.v20160413-1503"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160428-0800"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.12.0.v20160428-0800"/>
+      <unit id="org.eclipse.help.feature.group" version="2.2.0.v20160428-0800"/>
 
       <!-- DTP -->
-      <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.designer.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.designer.core.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.apache.derby.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.hsqldb.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.ibm.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.jdbc.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.jdt.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.msft.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.mysql.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oda.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oda.designer.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oracle.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.postgresql.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sap.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sybase.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.ingres.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sqlite.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.results.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.ddl.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.data.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.parsers.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.intro.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqltools.doc.user.feature.group" version="1.13.0.201512142037"/>
+      <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.designer.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.designer.core.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.apache.derby.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.hsqldb.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.ibm.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.jdbc.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.jdt.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.msft.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.mysql.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oda.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oda.designer.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oracle.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.postgresql.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sap.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sybase.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.ingres.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sqlite.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.results.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.ddl.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.data.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.parsers.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.intro.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqltools.doc.user.feature.group" version="1.13.0.201603142002"/>
 
       <!-- Recommenders for Java (and deps) -->
-      <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.3.0.v20160201-1617"/>
+      <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
       <unit id="org.eclipse.aether.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.file.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.http.feature.feature.group" version="1.0.1.v20141111"/>
@@ -231,52 +231,53 @@
       <!-- needed for JBoss Central -->
       <unit id="com.sun.syndication" version="0.9.0.v200803061811"/>
       <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160203-1727"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160330-0740"/>
 
-      <unit id="org.eclipse.ui" version="3.107.0.v20160108-0627"/>
-      <unit id="org.eclipse.core.runtime" version="3.12.0.v20160120-1402"/>
+      <unit id="org.eclipse.ui" version="3.107.0.v20160422-1755"/>
+      <unit id="org.eclipse.core.runtime" version="3.12.0.v20160427-1901"/>
 
-      <unit id="org.eclipse.core.resources" version="3.11.0.v20151214-2033"/>
-      <unit id="org.eclipse.ui.ide" version="3.12.0.v20160127-1632"/>
-      <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20160127-1539"/>
-      <unit id="org.eclipse.jface.text" version="3.11.0.v20160125-1610"/>
+      <unit id="org.eclipse.core.resources" version="3.11.0.v20160422-0304"/>
+      <unit id="org.eclipse.ui.ide" version="3.12.0.v20160427-1946"/>
+      <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20160425-1137"/>
+      <unit id="org.eclipse.jface.text" version="3.11.0.v20160425-1211"/>
       <!-- have to manually update this one if more than one version exists in SimRel mirror -->
       <!-- <unit id="org.eclipse.osgi" version="3.10.200.v20151207-2221"/> -->
-      <unit id="org.eclipse.core.filesystem" version="1.6.0.v20151007-1725"/>
-      <unit id="org.eclipse.ui.forms" version="3.7.0.v20160122-1127"/>
-      <unit id="org.eclipse.ui.editors" version="3.10.0.v20160120-1631"/>
-      <unit id="org.eclipse.team.core" version="3.7.100.v20150203-1452"/>
-      <unit id="org.eclipse.team.ui" version="3.7.300.v20151117-1911"/>
-      <unit id="org.eclipse.jface" version="3.12.0.v20160118-2055"/>
-      <unit id="org.eclipse.compare" version="3.5.700.v20151225-0213"/>
+      <unit id="org.eclipse.core.filesystem" version="1.6.0.v20160217-2331"/>
+      <unit id="org.eclipse.ui.forms" version="3.7.0.v20160310-0900"/>
+      <unit id="org.eclipse.ui.editors" version="3.10.0.v20160422-1639"/>
+      <unit id="org.eclipse.team.core" version="3.8.0.v20160418-1534"/>
+      <unit id="org.eclipse.team.ui" version="3.8.0.v20160418-1534"/>
+      <unit id="org.eclipse.jface" version="3.12.0.v20160411-2246"/>
+      <unit id="org.eclipse.compare" version="3.6.0.v20160418-1534"/>
 
       <!-- Zest -->
-      <unit id="org.eclipse.zest.feature.group" version="1.7.0.201602010304"/>
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201602010304"/>
-      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201602010304"/>
+      <unit id="org.eclipse.zest.feature.group" version="1.7.0.201605020204"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201605020204"/>
+      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201605020204"/>
 
       <!-- mylyn -->
-      <unit id="org.eclipse.mylyn_feature.feature.group" version="3.18.0.v20151211-2235"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.18.0.v20151116-1930"/>
-      <unit id="org.eclipse.mylyn.commons.identity.feature.group" version="1.10.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.commons.net" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.commons.notifications.feature.group" version="1.10.0.v20151102-1814"/>
-      <unit id="org.eclipse.mylyn.commons.repositories.feature.group" version="1.10.0.v20151116-1930"/>
-      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="3.18.0.v20151014-2324"/>
-      <unit id="org.eclipse.mylyn.discovery.feature.group" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.monitor.feature.group" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.tasks.core" version="3.18.0.v20151202-0115"/>
-      <unit id="org.eclipse.mylyn.tasks.ui" version="3.18.0.v20151211-2235"/>
-      <unit id="org.eclipse.mylyn.tasks.bugs" version="3.18.0.v20151009-2340"/>
+      <unit id="org.eclipse.mylyn_feature.feature.group" version="3.19.0.v20160331-1842"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.19.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.commons.identity.feature.group" version="1.11.0.v20160111-1919"/>
+      <unit id="org.eclipse.mylyn.commons.net" version="3.19.0.v20160111-1919"/>
+      <unit id="org.eclipse.mylyn.commons.notifications.feature.group" version="1.11.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.commons.repositories.feature.group" version="1.11.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="3.19.0.v20160316-2105"/>
+      <unit id="org.eclipse.mylyn.discovery.feature.group" version="3.19.0.v20160315-2132"/>
+      <unit id="org.eclipse.mylyn.monitor.feature.group" version="3.19.0.v20160315-2132"/>
+      <unit id="org.eclipse.mylyn.tasks.core" version="3.19.0.v20160316-2133"/>
+      <unit id="org.eclipse.mylyn.tasks.ui" version="3.19.0.v20160331-1842"/>
+      <unit id="org.eclipse.mylyn.tasks.bugs" version="3.19.0.v20160111-1939"/>
       <unit id="org.jsoup" version="1.7.2.v201411291515"/>
       <!-- These Mylyn/Bugzilla IUs are only necessary for tests -->
-      <unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.18.0.v20151009-2340"/>
-      <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.18.0.v20151013-1847"/>
-      <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.18.0.v20151009-1724"/>
+      <unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.19.0.v20160316-2133"/>
+      <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.19.0.v20160111-2059"/>
+      <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.19.0.v20160111-1919"/>
 
       <!-- egit -->
-      <unit id="org.eclipse.jgit.feature.group" version="4.2.0.201601211800-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="4.2.0.201601211800-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="4.4.0.201605041135-m1"/>
+      <unit id="org.eclipse.egit.feature.group" version="4.4.0.201605041135-m1"/>
+      <unit id="org.eclipse.egit.ui.smartimport" version="4.4.0.201605041135-m1"/>
 
       <!-- Required for Batch and Arquillian -->
       <unit id="org.eclipse.sapphire.feature.group" version="10.0.0.201510151906"/>
@@ -296,41 +297,41 @@
       <unit id="org.eclipse.rse.core" version="3.3.100.201407181907"/>
       <unit id="org.eclipse.rse.ui" version="3.3.100.201503112018"/>
       <unit id="org.eclipse.rse.connectorservice.ssh" version="2.1.300.201505220524"/>
-      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.core.expressions" version="3.5.0.v20160122-0423"/>
-      <unit id="org.eclipse.tm.terminal.view.core" version="4.0.0.201505101440"/>
-      <unit id="org.eclipse.tm.terminal.view.ui" version="4.0.0.201506031417"/>
-      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.0.0.201505101444"/>
-      <unit id="org.eclipse.tm.terminal.connector.serial.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.0.0.201506040610"/>
+      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.core.expressions" version="3.5.100.v20160418-1621"/>
+      <unit id="org.eclipse.tm.terminal.view.core" version="4.0.0.201512160834"/>
+      <unit id="org.eclipse.tm.terminal.view.ui" version="4.1.0.201603190819"/>
+      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.1.0.201509041418"/>
+      <unit id="org.eclipse.tm.terminal.connector.serial.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.1.0.201603190914"/>
       <!-- connector.local requires cdt.native -->
-      <unit id="org.eclipse.cdt.native.feature.group" version="9.0.0.201602011105"/>
+      <unit id="org.eclipse.cdt.native.feature.group" version="9.0.0.201605031942"/>
 
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.remote.core" version="2.0.0.201510151331"/>
-      <unit id="org.eclipse.remote.ui" version="2.0.0.201510151331"/>
+      <unit id="org.eclipse.remote.core" version="2.0.0.201605030021"/>
+      <unit id="org.eclipse.remote.ui" version="2.0.0.201605030021"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.9.0.N20160429-2231/"/>
       <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
-      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.8.0.N20160219-2043"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.N20160429-2231"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.9.0.N20160429-2231"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.9.0.N20160429-2231"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201601072102/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201604240412.neon.m7/"/>
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.launchbar.core" version="2.0.0.201601072102"/>
-      <unit id="org.eclipse.launchbar.ui" version="2.0.0.201601072102"/>
+      <unit id="org.eclipse.launchbar.core" version="2.0.0.201604240412"/>
+      <unit id="org.eclipse.launchbar.ui" version="2.0.0.201604240412"/>
     </location>
 
     <!-- TM and RSE are in Neon site but this way we get sources too; as of Neon M4, latest is 201511131000/features/org.eclipse.rse_3.7.0.201505221634.jar  -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tm/4.0.0.RC4/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tm/4.1.0.201603190914/"/>
       <unit id="org.eclipse.rse.feature.group" version="3.7.0.201505221634"/>
       <unit id="org.eclipse.rse.ssh.feature.group" version="3.7.0.201505221634"/>
       <unit id="org.eclipse.rse.terminals.feature.group" version="3.8.0.201505221634"/>
@@ -343,30 +344,30 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.5.v20151012/"/>
-      <unit id="org.eclipse.jetty.client" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.http" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.io" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.security" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.server" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.util" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.xml" version="9.3.5.v20151012"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.6.v20151106/"/>
+      <unit id="org.eclipse.jetty.client" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.io" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.security" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.xml" version="9.3.6.v20151106"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/atlassian/3.2.5.v20150427/"/>
-      <unit id="com.atlassian.connector.eclipse.jira.feature.group" version="3.2.5.v20150427"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/atlassian/3.2.5.I20150617-0100/"/>
+      <unit id="com.atlassian.connector.eclipse.jira.feature.group" version="3.2.5.I20150617-0100"/>
       <unit id="com.thoughtworks.xstream" version="1.3.0.v20100826-1640"/>
       <unit id="org.joda.time" version="1.6.0.v20081202-0100"/>
     </location>
@@ -389,63 +390,63 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M5-20160202064558/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M7-20160503010110/"/>
 
       <!-- JBIDE-21171 new for Neon M4 -->
-      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201601261551"/>
+      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
 
       <unit id="org.eclipse.jst.jee" version="1.0.700.v201404092004"/>
       <unit id="org.eclipse.jst.jee.web" version="1.0.500.v201404021628"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.6.3.v201508121553"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.jst.ws.axis2tools.feature.feature.group" version="1.1.301.v201410160332"/>
       <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.203.v201503151903"/>
 
-      <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.4.1.v201601152356"/>
-      <unit id="org.eclipse.jpt.common.eclipselink.feature.feature.group" version="1.3.101.v201510091940"/>
-      <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.1.v201601142211"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.4.2.v201601152356"/>
-      <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.2.v201601142211"/>
+      <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.5.0.v201603181811"/>
+      <unit id="org.eclipse.jpt.common.eclipselink.feature.feature.group" version="1.3.200.v201603180253"/>
+      <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.100.v201603180253"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
+      <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.100.v201603180253"/>
 
-      <unit id="org.eclipse.jsf.feature.feature.group" version="3.8.0.v201505112336"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.6.3.v201508121553"/>
-      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.6.0.v201405070205"/>
-      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.7.0.v201509222120"/>
+      <unit id="org.eclipse.jsf.feature.feature.group" version="3.8.0.v201603071844"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
+      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.6.0.v201602161345"/>
+      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.7.0.v201604301639"/>
       <unit id="org.eclipse.jst.enterprise_userdoc.feature.feature.group" version="3.6.0.v201405070205"/>
       <unit id="org.eclipse.jst.jsf.apache.trinidad.tagsupport.feature.feature.group" version="2.6.0.v201410101748"/>
-      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.500.v201508232344"/>
+      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.500.v201603031514"/>
       <unit id="org.eclipse.jst.server_adapters.feature.feature.group" version="3.2.400.v201503102136"/>
-      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.200.v201512031715"/>
-      <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.200.v201512031715"/>
+      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.300.v201603031514"/>
+      <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.300.v201603031514"/>
       <unit id="org.eclipse.jst.server_userdoc.feature.feature.group" version="3.3.300.v201503102136"/>
-      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.7.1.v201510300035"/>
-      <unit id="org.eclipse.jst.webpageeditor.feature.feature.group" version="2.7.1.v201508270443"/>
-      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.7.1.v201511240159"/>
+      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.8.0.v201604120230"/>
+      <unit id="org.eclipse.jst.webpageeditor.feature.feature.group" version="2.7.1.v201603071844"/>
+      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.8.0.v201604292217"/>
       <unit id="org.eclipse.jst.web_userdoc.feature.feature.group" version="3.6.0.v201405070205"/>
       <unit id="org.eclipse.jst.ws.axis2tools.feature.feature.group" version="1.1.301.v201410160332"/>
       <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.203.v201503151903"/>
       <unit id="org.eclipse.jst.ws.jaxws.dom.feature.feature.group" version="1.0.302.v201504272154"/>
-      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.202.v201504291921"/>
+      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.203.v201602092125"/>
       <unit id="org.eclipse.jst.ws.jaxws_userdoc.feature.feature.group" version="1.0.402.v201503151903"/>
 
       <unit id="org.eclipse.wst.common.frameworks" version="1.2.200.v201304241450"/>
       <unit id="org.eclipse.wst.common.project.facet.ui" version="1.4.600.v201505072140"/>
       <unit id="org.eclipse.wst.common_core.feature.feature.group" version="3.7.1.v201508262220"/>
       <unit id="org.eclipse.wst.common.fproj.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.7.2.v201510130022"/>
-      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="1.6.201.v201601262245"/>
+      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.8.0.v201603091933"/>
+      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.0.0.v201604300029"/>
       <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.403.v201508132126"/>
-      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201601132253"/>
-      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201601132253"/>
+      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201603031514"/>
+      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201604062105"/>
       <unit id="org.eclipse.wst.server_userdoc.feature.feature.group" version="3.3.300.v201405011426"/>
-      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.8.0.v201601291607"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.0.v201601291607"/>
+      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.8.0.v201604300029"/>
+      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.0.v201604300029"/>
       <unit id="org.eclipse.wst.web_userdoc.feature.feature.group" version="3.8.0.v201511030001"/>
       <unit id="org.eclipse.wst.ws_core.feature.feature.group" version="3.7.0.v201505131719"/>
-      <unit id="org.eclipse.wst.ws_ui.feature.feature.group" version="3.7.1.v201511240159"/>
+      <unit id="org.eclipse.wst.ws_ui.feature.feature.group" version="3.8.0.v201604291650"/>
       <unit id="org.eclipse.wst.ws_userdoc.feature.feature.group" version="3.1.400.v201405061938"/>
       <unit id="org.eclipse.wst.ws_wsdl15.feature.feature.group" version="1.5.400.v201405061938"/>
-      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.8.0.v201511030001"/>
-      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.8.0.v201511240159"/>
+      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.8.0.v201604291650"/>
+      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.8.0.v201604291650"/>
       <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="3.8.0.v201511030001"/>
       <unit id="org.eclipse.wst.xml.xpath2.processor.feature.feature.group" version="2.0.301.v201409111854"/>
       <unit id="org.eclipse.wst.xsl.feature.feature.group" version="1.3.401.v201509231858"/>
@@ -464,36 +465,36 @@
 
     <!-- JBIDE-19045 move Tern into JST project, so no longer in target platform -->
     
-    <!-- Easymport -->
+    <!-- JBIDE-22257 Easymport now part of platform so remove from here
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151123-1229-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.15.0.v20151110-2230/"/>
       <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151123-1229"/>
-      <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20150908-1034"/>
-      <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20150908-1034"/>
+      <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20160427-1136"/>
+      <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20160427-1136"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/egit/4.2.0.201601211800-r/"/>
-      <unit id="org.eclipse.egit.ui.importer" version="4.2.0.201601211800-r"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/egit/v4.4.0.201605041135-m1/"/>
+      <unit id="org.eclipse.egit.ui.smartimport" version="4.4.0.201605041135-m1"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jsdt/3.5.0.v201509081821-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jsdt/2.0.0.v201604262328/"/>
       <unit id="org.eclipse.wst.jsdt.ui.importer" version="0.0.1.v201509081821"/>
-    </location>
+    </location> -->
 
     <!-- Only in JBDS (shipped in installer): TestNG -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/testng/6.9.5.201506120235/"/>
-      <unit id="org.testng.eclipse.feature.group" version="6.9.5.201506120235"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/testng/6.9.11.201604020423/"/>
+      <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
     </location>
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201601192048/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.0.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201601192048"/>
-      <unit id="com.spotify.docker.client" version="3.1.10.v20151113-2033"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.0.0.201605032008/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.0.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="2.0.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="2.0.0.201605032008"/>
+      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
@@ -529,8 +530,8 @@
 
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201512072012-CI-B680/"/>
-      <unit id="org.dadacoalition.yedit" version="1.0.18.201506232135-RELEASE-SIGNED"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201602250914-RELEASE/"/>
+      <unit id="org.dadacoalition.yedit" version="1.0.18.201602092025-RELEASE-SIGNED"/>
       <unit id="org.yaml.snakeyaml" version="1.14.0.v201505061500"/>
     </location>
 

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -10,28 +10,28 @@
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20151204220443/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20160501200945/"/>
 
       <!-- for these IUs we need multiple versions -->
       <unit id="javax.wsdl" version="1.6.2.v201012040545"/>
       <unit id="javax.wsdl" version="1.5.1.v201012040544"/>
       <unit id="org.jdom" version="1.1.1.v201101151400"/>
-      <unit id="org.jdom" version="1.0.0.v201005080400"/>
+      <unit id="org.jdom" version="1.1.1.v201101151400"/>
       <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
       <unit id="javax.wsdl" version="1.6.2.v201012040545"/>
       <unit id="javax.wsdl" version="1.5.1.v201012040544"/>
       <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
-      <unit id="javax.xml.bind" version="2.1.9.v201005080401"/>
+      <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
       <unit id="javax.xml.soap" version="1.3.0.v201105210645"/>
       <unit id="javax.xml.soap" version="1.2.0.v201005080501"/>
       <unit id="org.apache.commons.collections" version="3.2.2.v201511171945"/>
       <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
       <unit id="org.apache.commons.logging" version="1.0.4.v201101211617"/>
-      <unit id="org.apache.lucene" version="2.9.1.v201101211721"/>
-      <unit id="org.apache.lucene" version="1.9.1.v201101211617"/>
+      <unit id="org.apache.lucene" version="3.5.0.v20120725-1805"/>
       <unit id="org.apache.lucene.core" version="3.5.0.v20120725-1805"/>
-      <unit id="org.apache.lucene.core" version="2.9.1.v201101211721"/>
+      <unit id="org.apache.lucene.misc" version="3.5.0.v20120725-1805"/>
+      <unit id="org.apache.lucene.queries" version="3.5.0.v20120725-1805"/>
       <unit id="org.junit" version="4.12.0.v201504281640"/>
 
       <!-- Orbit bundles -->
@@ -42,7 +42,7 @@
       <unit id="org.apache.axis" version="1.4.0.v201411182030"/>
       <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
       <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.commons.codec" version="1.3.0.v201101211617"/>
+      <unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
       <unit id="javax.ejb" version="3.1.1.v201204261316"/>
       <unit id="javax.transaction" version="1.1.1.v201105210645"/>
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
@@ -51,7 +51,7 @@
       <unit id="ch.qos.logback.classic" version="1.0.7.v20121108-1250"/>
       <unit id="ch.qos.logback.core" version="1.0.7.v20121108-1250"/>
       <!-- Needed by jbosstools-aerogear -->
-      <unit id="com.google.gson" version="2.1.0.v201303041604"/>
+      <unit id="com.google.gson" version="2.2.4.v201311231704"/>
 
       <!-- Needed for Mylyn/Bugzilla -->
       <unit id="org.apache.xmlrpc" version="3.0.0.v20100427-1100"/>
@@ -69,7 +69,7 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/1.1.0.201511082254/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tern/1.2.0.201604271713/"/>
       <!-- Required by FeedHenry module -->
       <unit id="minimal-json" version="0.9.4"/>
     </location>
@@ -90,8 +90,8 @@
       <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.2.0.201601252104"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-buildhelper/"/>
-      <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201212120353"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e-buildhelper/0.15.0.201405280027/"/>
+      <unit id="org.sonatype.m2e.buildhelper.feature.feature.group" version="0.15.0.201405280027"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201509090157/"/>
@@ -103,19 +103,19 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.0.201502101659"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160202-2119/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2e/1.7.0.20160504-0322/"/>
       <!--unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20151110-2248"/>
       <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20151110-2248"/-->
-      <unit id="org.eclipse.m2e.importer" version="1.7.0.20160202-2119"/>
+      <unit id="org.eclipse.m2e.importer" version="1.7.0.20160504-0322"/>
     </location>
 
     <!-- SimRel -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/neon/201602051000-M5/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/neon/201605061000-M7/"/>
 
       <!-- m2e -->
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160202-2119"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20160202-2119"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.7.0.20160504-0322"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.7.0.20160504-0322"/>
       <!-- m2e-wtp -->
       <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.3.0.20151111-2338"/>
       <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.3.0.20151111-2338"/>
@@ -124,95 +124,95 @@
 
       <!-- p2.discovery -->
       <unit id="org.eclipse.equinox.p2.discovery.compatibility" version="1.0.200.v20131211-1531"/>
-      <unit id="org.eclipse.equinox.p2.discovery" version="1.0.300.v20131210-1027"/>
+      <unit id="org.eclipse.equinox.p2.discovery" version="1.0.300.v20160419-0834"/>
       <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.0.100.v20150907-2149"/>
 
       <!-- ECF -->
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.2.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.12.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.12.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
-      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20151130-0157"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.3.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.feature.feature.group" version="3.13.1.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient4.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
+      <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.0.v20160405-1820"/>
       <unit id="org.eclipse.equinox.concurrent" version="1.1.0.v20130327-1442"/>
 
       <!-- EMF, XSD -->
-      <unit id="org.eclipse.emf.workspace.feature.group" version="1.10.0.201512152038"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201512142118"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="1.10.0.201512152038"/>
-      <unit id="org.eclipse.emf.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.codegen.feature.group" version="2.11.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.databinding.feature.group" version="1.4.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.11.0.v20160201-0859"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160128-0808"/>
-      <unit id="org.eclipse.emf.edit.feature.group" version="2.12.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.edit.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.editor.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.mapping.feature.group" version="2.9.0.v20160201-0859"/>
-      <unit id="org.eclipse.xsd.feature.group" version="2.12.0.v20160201-0859"/>
+      <unit id="org.eclipse.emf.workspace.feature.group" version="1.10.0.201605031913"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.10.0.201605030103"/>
+      <unit id="org.eclipse.emf.transaction.feature.group" version="1.10.0.201605031913"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.codegen.feature.group" version="2.11.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.databinding.feature.group" version="1.4.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.12.0.v20160420-0247"/>
+      <unit id="org.eclipse.emf.edit.feature.group" version="2.12.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.edit.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.editor.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.mapping.feature.group" version="2.9.0.v20160429-0808"/>
+      <unit id="org.eclipse.xsd.feature.group" version="2.12.0.v20160429-0808"/>
 
       <!-- GEF, Draw2D -->
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201602010304"/>
-      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201602010304"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201605020204"/>
+      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201605020204"/>
 
       <!-- Platform: CVS, JDT, RCP, PDE, Equinox, Help -->
-      <unit id="com.ibm.icu.base" version="54.1.1.v201511091919"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160128-2000"/>
-      <unit id="org.eclipse.cvs.feature.group" version="1.4.300.v20160128-2000"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.12.0.v20160128-2000"/>
-      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.4.0.v20160125-0953"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20160128-1437"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.300.v20150907-2149"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.200.v20160128-1810"/>
-      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.3.0.v20160115-0911"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160128-2000"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.12.0.v20160128-2000"/>
-      <unit id="org.eclipse.help.feature.group" version="2.2.0.v20160128-2000"/>
+      <unit id="com.ibm.icu.base" version="56.1.0.v201601250100"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.6.0.v20160428-0800"/>
+      <unit id="org.eclipse.cvs.feature.group" version="1.4.300.v20160428-0800"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.12.0.v20160428-0800"/>
+      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.4.0.v20160427-2120"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20160427-1608"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.400.v20160419-0834"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.200.v20160427-2220"/>
+      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.3.0.v20160413-1503"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.6.0.v20160428-0800"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.12.0.v20160428-0800"/>
+      <unit id="org.eclipse.help.feature.group" version="2.2.0.v20160428-0800"/>
 
       <!-- DTP -->
-      <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.designer.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.oda.designer.core.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.apache.derby.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.hsqldb.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.ibm.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.jdbc.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.jdt.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.msft.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.mysql.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oda.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oda.designer.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.oracle.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.postgresql.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sap.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sybase.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.ingres.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.enablement.sqlite.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.results.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.ddl.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.data.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.parsers.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.intro.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="1.13.0.201512142037"/>
-      <unit id="org.eclipse.datatools.sqltools.doc.user.feature.group" version="1.13.0.201512142037"/>
+      <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.designer.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.oda.designer.core.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.apache.derby.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.hsqldb.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.ibm.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.jdbc.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.jdt.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.msft.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.mysql.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oda.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oda.designer.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.oracle.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.postgresql.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sap.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sybase.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.ingres.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.enablement.sqlite.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.results.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.ddl.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.data.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.parsers.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.intro.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="1.13.0.201603142002"/>
+      <unit id="org.eclipse.datatools.sqltools.doc.user.feature.group" version="1.13.0.201603142002"/>
 
       <!-- Recommenders for Java (and deps) -->
-      <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.3.0.v20160201-1617"/>
+      <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
       <unit id="org.eclipse.aether.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.file.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.http.feature.feature.group" version="1.0.1.v20141111"/>
@@ -229,66 +229,53 @@
       <!-- needed for JBoss Central -->
       <unit id="com.sun.syndication" version="0.9.0.v200803061811"/>
       <!-- JBDS-3566 include AERI in JBDS (and later JBT) -->
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160203-1727"/>
+      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="1.100.0.v20160330-0740"/>
 
-      <unit id="org.eclipse.ui" version="3.107.0.v20160108-0627"/>
-      <unit id="org.eclipse.core.runtime" version="3.12.0.v20160120-1402"/>
+      <unit id="org.eclipse.ui" version="3.107.0.v20160422-1755"/>
+      <unit id="org.eclipse.core.runtime" version="3.12.0.v20160427-1901"/>
 
-      <unit id="org.eclipse.core.resources" version="3.11.0.v20151214-2033"/>
-      <unit id="org.eclipse.ui.ide" version="3.12.0.v20160127-1632"/>
-      <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20160127-1539"/>
-      <unit id="org.eclipse.jface.text" version="3.11.0.v20160125-1610"/>
+      <unit id="org.eclipse.core.resources" version="3.11.0.v20160422-0304"/>
+      <unit id="org.eclipse.ui.ide" version="3.12.0.v20160427-1946"/>
+      <unit id="org.eclipse.ui.workbench.texteditor" version="3.10.0.v20160425-1137"/>
+      <unit id="org.eclipse.jface.text" version="3.11.0.v20160425-1211"/>
       <!-- have to manually update this one if more than one version exists in SimRel mirror -->
       <!-- <unit id="org.eclipse.osgi" version="3.10.200.v20151207-2221"/> -->
-      <unit id="org.eclipse.core.filesystem" version="1.6.0.v20151007-1725"/>
-      <unit id="org.eclipse.ui.forms" version="3.7.0.v20160122-1127"/>
-      <unit id="org.eclipse.ui.editors" version="3.10.0.v20160120-1631"/>
-      <unit id="org.eclipse.team.core" version="3.7.100.v20150203-1452"/>
-      <unit id="org.eclipse.team.ui" version="3.7.300.v20151117-1911"/>
-      <unit id="org.eclipse.jface" version="3.12.0.v20160118-2055"/>
-      <unit id="org.eclipse.compare" version="3.5.700.v20151225-0213"/>
+      <unit id="org.eclipse.core.filesystem" version="1.6.0.v20160217-2331"/>
+      <unit id="org.eclipse.ui.forms" version="3.7.0.v20160310-0900"/>
+      <unit id="org.eclipse.ui.editors" version="3.10.0.v20160422-1639"/>
+      <unit id="org.eclipse.team.core" version="3.8.0.v20160418-1534"/>
+      <unit id="org.eclipse.team.ui" version="3.8.0.v20160418-1534"/>
+      <unit id="org.eclipse.jface" version="3.12.0.v20160411-2246"/>
+      <unit id="org.eclipse.compare" version="3.6.0.v20160418-1534"/>
 
       <!-- Zest -->
-      <unit id="org.eclipse.zest.feature.group" version="1.7.0.201602010304"/>
-      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201602010304"/>
-      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201602010304"/>
+      <unit id="org.eclipse.zest.feature.group" version="1.7.0.201605020204"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201605020204"/>
+      <unit id="org.eclipse.gef.feature.group" version="3.11.0.201605020204"/>
 
       <!-- mylyn -->
-      <unit id="org.eclipse.mylyn_feature.feature.group" version="3.18.0.v20151211-2235"/>
-      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.18.0.v20151116-1930"/>
-      <unit id="org.eclipse.mylyn.commons.identity.feature.group" version="1.10.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.commons.net" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.commons.notifications.feature.group" version="1.10.0.v20151102-1814"/>
-      <unit id="org.eclipse.mylyn.commons.repositories.feature.group" version="1.10.0.v20151116-1930"/>
-      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="3.18.0.v20151014-2324"/>
-      <unit id="org.eclipse.mylyn.discovery.feature.group" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.monitor.feature.group" version="3.18.0.v20151009-1724"/>
-      <unit id="org.eclipse.mylyn.tasks.core" version="3.18.0.v20151202-0115"/>
-      <unit id="org.eclipse.mylyn.tasks.ui" version="3.18.0.v20151211-2235"/>
-      <unit id="org.eclipse.mylyn.tasks.bugs" version="3.18.0.v20151009-2340"/>
+      <unit id="org.eclipse.mylyn_feature.feature.group" version="3.19.0.v20160331-1842"/>
+      <unit id="org.eclipse.mylyn.commons.feature.group" version="3.19.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.commons.identity.feature.group" version="1.11.0.v20160111-1919"/>
+      <unit id="org.eclipse.mylyn.commons.net" version="3.19.0.v20160111-1919"/>
+      <unit id="org.eclipse.mylyn.commons.notifications.feature.group" version="1.11.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.commons.repositories.feature.group" version="1.11.0.v20160316-2122"/>
+      <unit id="org.eclipse.mylyn.context_feature.feature.group" version="3.19.0.v20160316-2105"/>
+      <unit id="org.eclipse.mylyn.discovery.feature.group" version="3.19.0.v20160315-2132"/>
+      <unit id="org.eclipse.mylyn.monitor.feature.group" version="3.19.0.v20160315-2132"/>
+      <unit id="org.eclipse.mylyn.tasks.core" version="3.19.0.v20160316-2133"/>
+      <unit id="org.eclipse.mylyn.tasks.ui" version="3.19.0.v20160331-1842"/>
+      <unit id="org.eclipse.mylyn.tasks.bugs" version="3.19.0.v20160111-1939"/>
       <unit id="org.jsoup" version="1.7.2.v201411291515"/>
       <!-- These Mylyn/Bugzilla IUs are only necessary for tests -->
-      <unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.18.0.v20151009-2340"/>
-      <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.18.0.v20151013-1847"/>
-      <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.18.0.v20151009-1724"/>
+      <unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.19.0.v20160316-2133"/>
+      <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.19.0.v20160111-2059"/>
+      <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.19.0.v20160111-1919"/>
 
       <!-- egit -->
-      <unit id="org.eclipse.jgit.feature.group" version="4.2.0.201601211800-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="4.2.0.201601211800-r"/>
-
-      <!-- Only in JBT: JBIDE-16794 Apache Batik 1.6.0 is required by BIRT, but BIRT site only contains 1.7.0 -->
-      <unit id="org.apache.batik.bridge" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.css" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.dom" version="1.6.1.v201505192100"/>
-      <unit id="org.apache.batik.dom.svg" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.ext.awt" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.parser" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.pdf" version="1.6.0.v201105071520"/>
-      <unit id="org.apache.batik.svggen" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.transcoder" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.util" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.util.gui" version="1.6.0.v201011041432"/>
-      <unit id="org.apache.batik.xml" version="1.6.0.v201011041432"/>
+      <unit id="org.eclipse.jgit.feature.group" version="4.4.0.201605041135-m1"/>
+      <unit id="org.eclipse.egit.feature.group" version="4.4.0.201605041135-m1"/>
+      <unit id="org.eclipse.egit.ui.smartimport" version="4.4.0.201605041135-m1"/>
 
       <!-- Required for Batch and Arquillian -->
       <unit id="org.eclipse.sapphire.feature.group" version="10.0.0.201510151906"/>
@@ -308,41 +295,41 @@
       <unit id="org.eclipse.rse.core" version="3.3.100.201407181907"/>
       <unit id="org.eclipse.rse.ui" version="3.3.100.201503112018"/>
       <unit id="org.eclipse.rse.connectorservice.ssh" version="2.1.300.201505220524"/>
-      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.core.expressions" version="3.5.0.v20160122-0423"/>
-      <unit id="org.eclipse.tm.terminal.view.core" version="4.0.0.201505101440"/>
-      <unit id="org.eclipse.tm.terminal.view.ui" version="4.0.0.201506031417"/>
-      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.0.0.201505101444"/>
-      <unit id="org.eclipse.tm.terminal.connector.serial.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.0.0.201506040610"/>
-      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.0.0.201506040610"/>
+      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.core.expressions" version="3.5.100.v20160418-1621"/>
+      <unit id="org.eclipse.tm.terminal.view.core" version="4.0.0.201512160834"/>
+      <unit id="org.eclipse.tm.terminal.view.ui" version="4.1.0.201603190819"/>
+      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.1.0.201509041418"/>
+      <unit id="org.eclipse.tm.terminal.connector.serial.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.1.0.201603190914"/>
+      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.1.0.201603190914"/>
       <!-- connector.local requires cdt.native -->
-      <unit id="org.eclipse.cdt.native.feature.group" version="9.0.0.201602011105"/>
+      <unit id="org.eclipse.cdt.native.feature.group" version="9.0.0.201605031942"/>
 
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.remote.core" version="2.0.0.201510151331"/>
-      <unit id="org.eclipse.remote.ui" version="2.0.0.201510151331"/>
+      <unit id="org.eclipse.remote.core" version="2.0.0.201605030021"/>
+      <unit id="org.eclipse.remote.ui" version="2.0.0.201605030021"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.9.0.N20160429-2231/"/>
       <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
-      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.8.0.N20160219-2043"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.N20160429-2231"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.9.0.N20160429-2231"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.9.0.N20160429-2231"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201601072102/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201604240412.neon.m7/"/>
       <!-- JBIDE-19879 required by new launchbar -->
-      <unit id="org.eclipse.launchbar.core" version="2.0.0.201601072102"/>
-      <unit id="org.eclipse.launchbar.ui" version="2.0.0.201601072102"/>
+      <unit id="org.eclipse.launchbar.core" version="2.0.0.201604240412"/>
+      <unit id="org.eclipse.launchbar.ui" version="2.0.0.201604240412"/>
     </location>
 
     <!-- TM and RSE are in Neon site but this way we get sources too; as of Neon M4, latest is 201511131000/features/org.eclipse.rse_3.7.0.201505221634.jar  -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tm/4.0.0.RC4/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/tm/4.1.0.201603190914/"/>
       <unit id="org.eclipse.rse.feature.group" version="3.7.0.201505221634"/>
       <unit id="org.eclipse.rse.ssh.feature.group" version="3.7.0.201505221634"/>
       <unit id="org.eclipse.rse.terminals.feature.group" version="3.8.0.201505221634"/>
@@ -355,37 +342,30 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.5.v20151012/"/>
-      <unit id="org.eclipse.jetty.client" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.http" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.io" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.security" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.server" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.util" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.xml" version="9.3.5.v20151012"/>
-
-      <!-- Only in JBT: Required by birt -->
-      <unit id="org.eclipse.jetty.osgi.boot" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.deploy" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.annotations" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.plus" version="9.3.5.v20151012"/>
-      <unit id="org.eclipse.jetty.jndi" version="9.3.5.v20151012"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.6.v20151106/"/>
+      <unit id="org.eclipse.jetty.client" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.io" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.security" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.6.v20151106"/>
+      <unit id="org.eclipse.jetty.xml" version="9.3.6.v20151106"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/atlassian/3.2.5.v20150427/"/>
-      <unit id="com.atlassian.connector.eclipse.jira.feature.group" version="3.2.5.v20150427"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/atlassian/3.2.5.I20150617-0100/"/>
+      <unit id="com.atlassian.connector.eclipse.jira.feature.group" version="3.2.5.I20150617-0100"/>
       <unit id="com.thoughtworks.xstream" version="1.3.0.v20100826-1640"/>
       <unit id="org.joda.time" version="1.6.0.v20081202-0100"/>
     </location>
@@ -408,63 +388,63 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M5-20160202064558/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M7-20160503010110/"/>
 
       <!-- JBIDE-21171 new for Neon M4 -->
-      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201601261551"/>
+      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
 
       <unit id="org.eclipse.jst.jee" version="1.0.700.v201404092004"/>
       <unit id="org.eclipse.jst.jee.web" version="1.0.500.v201404021628"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.6.3.v201508121553"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.jst.ws.axis2tools.feature.feature.group" version="1.1.301.v201410160332"/>
       <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.203.v201503151903"/>
 
-      <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.4.1.v201601152356"/>
-      <unit id="org.eclipse.jpt.common.eclipselink.feature.feature.group" version="1.3.101.v201510091940"/>
-      <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.1.v201601142211"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.4.2.v201601152356"/>
-      <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.2.v201601142211"/>
+      <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.5.0.v201603181811"/>
+      <unit id="org.eclipse.jpt.common.eclipselink.feature.feature.group" version="1.3.200.v201603180253"/>
+      <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.100.v201603180253"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.0.v201603181811"/>
+      <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.100.v201603180253"/>
 
-      <unit id="org.eclipse.jsf.feature.feature.group" version="3.8.0.v201505112336"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.6.3.v201508121553"/>
-      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.6.0.v201405070205"/>
-      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.7.0.v201509222120"/>
+      <unit id="org.eclipse.jsf.feature.feature.group" version="3.8.0.v201603071844"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
+      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.6.0.v201602161345"/>
+      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.7.0.v201604301639"/>
       <unit id="org.eclipse.jst.enterprise_userdoc.feature.feature.group" version="3.6.0.v201405070205"/>
       <unit id="org.eclipse.jst.jsf.apache.trinidad.tagsupport.feature.feature.group" version="2.6.0.v201410101748"/>
-      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.500.v201508232344"/>
+      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.500.v201603031514"/>
       <unit id="org.eclipse.jst.server_adapters.feature.feature.group" version="3.2.400.v201503102136"/>
-      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.200.v201512031715"/>
-      <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.200.v201512031715"/>
+      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.300.v201603031514"/>
+      <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.300.v201603031514"/>
       <unit id="org.eclipse.jst.server_userdoc.feature.feature.group" version="3.3.300.v201503102136"/>
-      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.7.1.v201510300035"/>
-      <unit id="org.eclipse.jst.webpageeditor.feature.feature.group" version="2.7.1.v201508270443"/>
-      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.7.1.v201511240159"/>
+      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.8.0.v201604120230"/>
+      <unit id="org.eclipse.jst.webpageeditor.feature.feature.group" version="2.7.1.v201603071844"/>
+      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.8.0.v201604292217"/>
       <unit id="org.eclipse.jst.web_userdoc.feature.feature.group" version="3.6.0.v201405070205"/>
       <unit id="org.eclipse.jst.ws.axis2tools.feature.feature.group" version="1.1.301.v201410160332"/>
       <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.203.v201503151903"/>
       <unit id="org.eclipse.jst.ws.jaxws.dom.feature.feature.group" version="1.0.302.v201504272154"/>
-      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.202.v201504291921"/>
+      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.203.v201602092125"/>
       <unit id="org.eclipse.jst.ws.jaxws_userdoc.feature.feature.group" version="1.0.402.v201503151903"/>
 
       <unit id="org.eclipse.wst.common.frameworks" version="1.2.200.v201304241450"/>
       <unit id="org.eclipse.wst.common.project.facet.ui" version="1.4.600.v201505072140"/>
       <unit id="org.eclipse.wst.common_core.feature.feature.group" version="3.7.1.v201508262220"/>
       <unit id="org.eclipse.wst.common.fproj.feature.group" version="3.7.0.v201505072140"/>
-      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.7.2.v201510130022"/>
-      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="1.6.201.v201601262245"/>
+      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.8.0.v201603091933"/>
+      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.0.0.v201604300029"/>
       <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.403.v201508132126"/>
-      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201601132253"/>
-      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201601132253"/>
+      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201603031514"/>
+      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201604062105"/>
       <unit id="org.eclipse.wst.server_userdoc.feature.feature.group" version="3.3.300.v201405011426"/>
-      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.8.0.v201601291607"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.0.v201601291607"/>
+      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.8.0.v201604300029"/>
+      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.8.0.v201604300029"/>
       <unit id="org.eclipse.wst.web_userdoc.feature.feature.group" version="3.8.0.v201511030001"/>
       <unit id="org.eclipse.wst.ws_core.feature.feature.group" version="3.7.0.v201505131719"/>
-      <unit id="org.eclipse.wst.ws_ui.feature.feature.group" version="3.7.1.v201511240159"/>
+      <unit id="org.eclipse.wst.ws_ui.feature.feature.group" version="3.8.0.v201604291650"/>
       <unit id="org.eclipse.wst.ws_userdoc.feature.feature.group" version="3.1.400.v201405061938"/>
       <unit id="org.eclipse.wst.ws_wsdl15.feature.feature.group" version="1.5.400.v201405061938"/>
-      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.8.0.v201511030001"/>
-      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.8.0.v201511240159"/>
+      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.8.0.v201604291650"/>
+      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.8.0.v201604291650"/>
       <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="3.8.0.v201511030001"/>
       <unit id="org.eclipse.wst.xml.xpath2.processor.feature.feature.group" version="2.0.301.v201409111854"/>
       <unit id="org.eclipse.wst.xsl.feature.feature.group" version="1.3.401.v201509231858"/>
@@ -488,16 +468,6 @@
       <unit id="org.jboss.reddeer.junit.extension.feature.feature.group" version="1.0.1.Final"/>
     </location>
 
-    <!-- Only in JBT: BIRT -->
-    <!-- JBIDE-16794 BIRT site only contains Apache Batik 1.7.0, but it depends on 1.6.0 (both are in Luna M6). See above -->
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.6.0.v201602022206/"/>
-      <unit id="org.eclipse.birt.feature.group" version="4.6.0.v201602022206"/>
-      <unit id="org.eclipse.birt.chart.feature.group" version="4.6.0.v201602022206"/>
-      <unit id="org.eclipse.birt.integration.wtp.feature.group" version="4.6.0.v201602022206"/>
-      <unit id="org.eclipse.birt.chart.integration.wtp.feature.group" version="4.6.0.v201602022206"/>
-    </location>
-
     <!-- TODO remove this
     https://issues.jboss.org/browse/JBIDE-21382 Required by o.j.t.common.model.ui, 
     o.e.platform.feature, o.e.m2e.feature, o.e.datatools.oda.cshelp, o.aspectj.ajde, o.e.wst.xml.xpath.core, 
@@ -511,30 +481,30 @@
 
     <!-- JBIDE-19045 move Tern into JST project, so no longer in target platform -->
     
-    <!-- Easymport -->
+    <!-- JBIDE-22257 Easymport now part of platform so remove from here
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.2.0.v20151123-1229-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/e4.ui/0.15.0.v20151110-2230/"/>
       <unit id="org.eclipse.e4.ui.importer" version="0.2.0.v20151123-1229"/>
-      <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20150908-1034"/>
-      <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20150908-1034"/>
+      <unit id="org.eclipse.e4.ui.importer.java" version="0.2.0.v20160427-1136"/>
+      <unit id="org.eclipse.e4.ui.importer.pde" version="0.2.0.v20160427-1136"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/egit/4.2.0.201601211800-r/"/>
-      <unit id="org.eclipse.egit.ui.importer" version="4.2.0.201601211800-r"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/egit/v4.4.0.201605041135-m1/"/>
+      <unit id="org.eclipse.egit.ui.smartimport" version="4.4.0.201605041135-m1"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jsdt/3.5.0.v201509081821-SNAPSHOT/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jsdt/2.0.0.v201604262328/"/>
       <unit id="org.eclipse.wst.jsdt.ui.importer" version="0.0.1.v201509081821"/>
-    </location>
+    </location> -->
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/1.2.1.201601192048/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="1.2.0.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.1.201601192048"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="1.2.1.201601192048"/>
-      <unit id="com.spotify.docker.client" version="3.1.10.v20151113-2033"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.0.0.201605032008/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.0.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="2.0.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.0.201605032008"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="2.0.0.201605032008"/>
+      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
@@ -570,8 +540,8 @@
 
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201512072012-CI-B680/"/>
-      <unit id="org.dadacoalition.yedit" version="1.0.18.201506232135-RELEASE-SIGNED"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201602250914-RELEASE/"/>
+      <unit id="org.dadacoalition.yedit" version="1.0.18.201602092025-RELEASE-SIGNED"/>
       <unit id="org.yaml.snakeyaml" version="1.14.0.v201505061500"/>
     </location>
 

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -213,6 +213,7 @@
 
       <!-- Recommenders for Java (and deps) -->
       <unit id="org.eclipse.recommenders.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
+      <unit id="org.eclipse.recommenders.snipmatch.rcp.feature.feature.group" version="2.4.0.v20160503-1414"/>
       <unit id="org.eclipse.aether.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.file.feature.feature.group" version="1.0.1.v20141111"/>
       <unit id="org.eclipse.aether.transport.http.feature.feature.group" version="1.0.1.v20141111"/>
@@ -389,10 +390,6 @@
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.8.0M7-20160503010110/"/>
-
-      <!-- JBIDE-21171 new for Neon M4 -->
-      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
-
       <unit id="org.eclipse.jst.jee" version="1.0.700.v201404092004"/>
       <unit id="org.eclipse.jst.jee.web" version="1.0.500.v201404021628"/>
       <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.8.0.v201603091933"/>
@@ -432,6 +429,9 @@
       <unit id="org.eclipse.wst.common.fproj.feature.group" version="3.7.0.v201505072140"/>
       <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.8.0.v201603091933"/>
       <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.0.0.v201604300029"/>
+      <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.0.0.v201604282302"/>
+      <unit id="org.eclipse.wst.json_ui.feature.feature.group" version="1.0.0.v201604280217"/>
+      <unit id="org.eclipse.wst.json_core.feature.feature.group" version="1.0.0.v201604280217"/>
       <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.403.v201508132126"/>
       <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.601.v201603031514"/>
       <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.653.v201604062105"/>
@@ -463,9 +463,9 @@
 
     <!-- Only in JBT, for integration-tests: Red Deer -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/stable/mars/core/reddeer/1.0.1/"/>
-      <unit id="org.jboss.reddeer.eclipse.feature.feature.group" version="1.0.1.Final"/>
-      <unit id="org.jboss.reddeer.junit.extension.feature.feature.group" version="1.0.1.Final"/>
+      <repository location="http://download.jboss.org/jbosstools/neon/snapshots/updates/reddeer/1.1.0.20160426/"/>
+      <unit id="org.jboss.reddeer.eclipse.feature.feature.group" version="1.1.0.201604261406"/>
+      <unit id="org.jboss.reddeer.junit.extension.feature.feature.group" version="1.1.0.201604261406"/>
     </location>
 
     <!-- TODO remove this
@@ -500,6 +500,7 @@
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.0.0.201605032008/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.core" version="2.0.0.201605032008"/>
       <unit id="org.eclipse.linuxtools.docker.docs" version="1.2.0.201605032008"/>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 		<tychoVersion>0.23.1</tychoVersion>
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
-		<jbossTychoPluginsVersion>0.23.1</jbossTychoPluginsVersion>
+		<jbossTychoPluginsVersion>0.23.4-SNAPSHOT</jbossTychoPluginsVersion>
 		<!-- JBIDE-21120 when deploying a non-SNAPSHOT, override these values in Jenkins or via commandline using values in distributionManagement below -->
 		<deploymentRepositoryId>jboss-snapshots-repository</deploymentRepositoryId>
 		<deploymentURL>https://${jbossNexus}/nexus/content/repositories/snapshots/</deploymentURL>


### PR DESCRIPTION
JBIDE-22200 move up to Neon.0.M7; use correct neon.0.M7 site, not the prelim one I created a day earlier (which had the wrong metadata + still included OTDT stuff)
JBIDE-22257 remove e4.ui.importer and related stuff
JBIDE-21066 update tm.terminal
JBIDE-21861 update docker tools
JBIDE-21105 remove birt

JBIDE-21621 update red deer
JBIDE-21861 update docker tooling and add vagrant
JBIDE-22196 add org.eclipse.recommenders.snipmatch.rcp feature
JBIDE-21439 add JSON editor org.eclipse.wst.json features