### PR TITLE
JBIDE-22200 rollback jetty from...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -346,25 +346,25 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.6.v20151106/"/>
-      <unit id="org.eclipse.jetty.client" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.http" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.io" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.security" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.server" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.util" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.xml" version="9.3.6.v20151106"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.5.v20151012/"/>
+      <unit id="org.eclipse.jetty.client" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.io" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.security" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.xml" version="9.3.5.v20151012"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -344,25 +344,25 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.6.v20151106/"/>
-      <unit id="org.eclipse.jetty.client" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.http" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.io" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.security" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.server" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.util" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.6.v20151106"/>
-      <unit id="org.eclipse.jetty.xml" version="9.3.6.v20151106"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.3.5.v20151012/"/>
+      <unit id="org.eclipse.jetty.client" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.http" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.io" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.security" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.server" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.util" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.3.5.v20151012"/>
+      <unit id="org.eclipse.jetty.xml" version="9.3.5.v20151012"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">


### PR DESCRIPTION
JBIDE-22200 rollback jetty from 9.3.6.v20151106 to 9.3.5.v20151012 to be consistent w/ what's in Neon.0.M7 and avoid having 2 different versions (versionwatch complains)