### PR TITLE
JBIDE 22611- use org.eclipse.mylyn.wikitext 2.8.0 feature (remove conflict)

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -275,7 +275,7 @@
       <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.20.0.v20160421-1902"/>
       <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.20.0.v20160421-1819"/>
       <!-- WikiText -->
-      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.v20160601-1831"/>
+      <!-- JBIDE-22611: <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.v20160601-1831"/> -->
 
       <!-- egit -->
       <unit id="org.eclipse.jgit.feature.group" version="4.4.0.201606070830-r"/>
@@ -328,8 +328,10 @@
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
       <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.8.0.N20160219-2043"/>
+      <!--
       <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/> -->
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -273,7 +273,7 @@
       <unit id="org.eclipse.mylyn.bugzilla.ide" version="3.20.0.v20160421-1902"/>
       <unit id="org.eclipse.mylyn.commons.xmlrpc" version="3.20.0.v20160421-1819"/>
       <!-- WikiText -->
-      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.v20160601-1831"/>
+      <!-- JBIDE-22611: <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.v20160601-1831"/> -->
 
       <!-- egit -->
       <unit id="org.eclipse.jgit.feature.group" version="4.4.0.201606070830-r"/>
@@ -326,8 +326,10 @@
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
       <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.8.0.N20160219-2043"/>
+      <!--
       <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
+      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/> -->
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">


### PR DESCRIPTION
@nickboldt - This PR should get me past the org.eclipse.mylyn.wikitext conflict.  I decided to use the 2.8.0 feature instead of the 2.9.0 to hopefully accommodate JBIDE-20216 but clearly flip it back tp use 2.9.0 if you'd like.  Either way - please respin your 4.60.1.AM1-SNAPSHOT and I'll see how far I get.
Thkx!
