### PR TITLE
remove mylyn-extras/2.8.0.N20160219-2043 and...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -76,7 +76,7 @@
 
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
         <repository location="https://repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/update.site/1.3.0.Final/update.site-1.3.0.Final.zip-unzip/"/>
-	<!-- For Jetty websocket 9.2.13 -->
+		<!-- For Jetty websocket 9.2.13 -->
         <unit id="org.apache.aries.util" version="1.1.1"/>
         <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.0.2"/>
     </location>

--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -326,13 +326,6 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
-      <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201606032238.neon.rc4/"/>
       <unit id="org.eclipse.launchbar.feature.group" version="2.0.0.201606032238"/>
     </location>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -76,10 +76,10 @@
 
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
         <repository location="https://repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/update.site/1.3.0.Final/update.site-1.3.0.Final.zip-unzip/"/>
-	<!-- Only in JBT: Test dependencies -->
+		<!-- Only in JBT: Test dependencies -->
         <unit id="org.jboss.tools.locus.mockito" version="1.9.5.v20131024-0922"/>
         <unit id="org.assertj.core" version="2.1.0"/>
-	<!-- For Jetty websocket 9.2.13 -->
+		<!-- For Jetty websocket 9.2.13 -->
         <unit id="org.apache.aries.util" version="1.1.1"/>
         <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.0.2"/>
     </location>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -324,13 +324,6 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-extras/2.8.0.N20160219-2043/"/>
-      <!-- JBIDE-20216 wikitext asciidoc editor; exclude creole and commonmark plugins -->
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.core" version="2.8.0.N20160111-1930"/>
-      <unit id="org.eclipse.mylyn.wikitext.asciidoc.ui" version="2.8.0.N20160111-1930"/>
-    </location>
-
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201606032238.neon.rc4/"/>
       <unit id="org.eclipse.launchbar.feature.group" version="2.0.0.201606032238"/>
     </location>


### PR DESCRIPTION
remove mylyn-extras/2.8.0.N20160219-2043 and org.eclipse.mylyn.wikitext.asciidoc.core/ui 2.8.0.N20160111-1930 as these are now included in Neon.0 within org.eclipse.mylyn.wikitext_feature_2.9.0.v20160601-1831.jar