### PR TITLE
JBIDE-22673: enable checkProvisioning for TP

### DIFF
--- a/jbdevstudio/multiple/pom.xml
+++ b/jbdevstudio/multiple/pom.xml
@@ -34,6 +34,7 @@
 							</targetFiles>
 							<failOnError>${validate-target-platform.failOnError}</failOnError>
 							<checkDependencies>true</checkDependencies>
+							<checkProvisioning>true</checkProvisioning>
 						</configuration>
 					</execution>
 				</executions>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -34,6 +34,7 @@
 							</targetFiles>
 							<failOnError>${validate-target-platform.failOnError}</failOnError>
 							<checkDependencies>true</checkDependencies>
+							<checkProvisioning>true</checkProvisioning>
 						</configuration>
 					</execution>
 				</executions>
@@ -109,5 +110,12 @@
 			</build>
 		</profile>
 	</profiles>
+
+<pluginRepositories>
+   <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+   </pluginRepository>
+</pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tychoVersion>0.25.0</tychoVersion>
+		<tychoVersion>0.26.0-SNAPSHOT</tychoVersion>
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
 		<jbossTychoPluginsVersion>0.25.0-SNAPSHOT</jbossTychoPluginsVersion>
 		<!-- JBIDE-21120 when deploying a non-SNAPSHOT, override these values in Jenkins or via commandline using values in distributionManagement below -->
@@ -180,6 +180,9 @@
 			<url>https://oss.sonatype.org/content/groups/public</url>
 		</pluginRepository>
 		<pluginRepository>
+			<id>tycho-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+		</pluginRepository>
 			<id>jboss-releases</id>
 			<name>JBoss Releases Maven Repository</name>
 			<url>https://${jbossNexus}/nexus/content/repositories/releases/</url>


### PR DESCRIPTION
This new check verifies that all content listed in TP can be installed
at once in the same provisioning operation.
It can typically detect missing dependencies or conflicting versions of
singletons.