### PR TITLE
JBIDE-22998 move up to Docker Tools from...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -467,12 +467,12 @@
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608232052/"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.0.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608232052"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608310043/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608310043"/>
       <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -478,12 +478,12 @@
     
     <!-- Eclipse Docker Tooling -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608232052/"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.0.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608232052"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608232052"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608310043/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608310043"/>
+      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608310043"/>
       <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
       <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
       <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>


### PR DESCRIPTION
JBIDE-22998 move up to Docker Tools from Neon.1.RC2 (2.x.0.201608232052 -> 2.1.0.201608310043)