### PR TITLE
remove...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -417,13 +417,6 @@
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn/3.11.0-v20140314-2044/"/>
       <unit id="org.eclipse.mylyn.commons.soap_feature.feature.group" version="3.11.0.v20131219-1119"/>
     </location>
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/luna/201406120900-RC4/"/>
-      <!-- requested in JBDS-3082 / JBDS-2991 -->
-      <!-- No more part of Eclipse release train since Luna SR1 -->
-      <!-- May be unnecessary when updating to newer atlassian plugins -->
-      <unit id="org.eclipse.core.runtime.compatibility.auth" version="3.2.300.v20120523-2004"/>
-    </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/R-3.8.1-20160912100321/"/>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -415,13 +415,6 @@
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn/3.11.0-v20140314-2044/"/>
       <unit id="org.eclipse.mylyn.commons.soap_feature.feature.group" version="3.11.0.v20131219-1119"/>
     </location>
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/luna/201406120900-RC4/"/>
-      <!-- requested in JBDS-3082 / JBDS-2991 -->
-      <!-- No more part of Eclipse release train since Luna SR1 -->
-      <!-- May be unnecessary when updating to newer atlassian plugins -->
-      <unit id="org.eclipse.core.runtime.compatibility.auth" version="3.2.300.v20120523-2004"/>
-    </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/webtools/R-3.8.1-20160912100321/"/>


### PR DESCRIPTION
remove org.eclipse.core.runtime.compatibility.auth as no longer referenced by anything in jbosstools or devstudio (was needed for Atlassian JIRA client in Central, v3.2.2, but we now include 3.2.5)