### PR TITLE
JBIDE-23481 include 3rd party sources in the...

### DIFF
--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -14,6 +14,8 @@
 	<properties>
 		<!-- set this to false to allow validation to proceed but NOT fail the build -->
 		<validate-target-platform.failOnError>true</validate-target-platform.failOnError>
+		<!-- JBIDE-23481 include 3rd party sources in the jbosstools target platform, but NOT the devstudio one -->
+		<mirror-target-to-repo.includeSources>true</mirror-target-to-repo.includeSources>
 	</properties>
 
 	<build>


### PR DESCRIPTION
JBIDE-23481 include 3rd party sources in the jbosstools target platform, but NOT the devstudio one

Signed-off-by: nickboldt <nboldt@redhat.com>