### PR TITLE
use applicationsArgs instead of appArgLine,...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 									<arg>org.eclipse.equinox.p2.example.p2diff.application</arg>
 									<arg>-outputFile=${project.build.directory}/${project.artifactId}-ignoreVersions.p2diff</arg>
 									<arg>-mode=ignoreVersions</arg>
-									<arg>file:${project.build.directory}/${project.artifactId}.target.repo</arg>
+									<arg>file://${project.build.directory}/${project.artifactId}.target.repo</arg>
 									<arg>${targetRepositoryUrl}</arg>
 								</applicationsArgs>
 							</configuration>
@@ -144,7 +144,13 @@
 								<goal>eclipse-run</goal>
 							</goals>
 							<configuration>
-								<appArgLine>-application org.eclipse.equinox.p2.example.p2diff.application -outputFile=${project.build.directory}/${project.artifactId}-considerVersions.p2diff file:${project.build.directory}/${project.artifactId}.target.repo ${targetRepositoryUrl}</appArgLine>
+								<applicationsArgs>
+									<arg>-application</arg>
+									<arg>org.eclipse.equinox.p2.example.p2diff.application</arg>
+									<arg>-outputFile=${project.build.directory}/${project.artifactId}-considerVersions.p2diff</arg>
+									<arg>file://${project.build.directory}/${project.artifactId}.target.repo</arg>
+									<arg>${targetRepositoryUrl}</arg>
+								</applicationsArgs>
 							</configuration>
 						</execution>
 					</executions>


### PR DESCRIPTION
use applicationsArgs instead of appArgLine, as we do for the ignoreVersions.p2diff file (consistency\!) - JBIDE-23503

Signed-off-by: nickboldt <nboldt@redhat.com>