### PR TITLE
JBIDE-24382 bump up to latest docker tooling...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbdevstudiotarget-4.60.3.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbdevstudiotarget-4.60.3.Final-SNAPSHOT">
   <!-- Pro tip: to convert
       from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
     to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>
@@ -116,6 +116,10 @@
       <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.3.2.20161026-1738"/>
       <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.3.2.20161026-1738"/>
       <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.3.2.20161026-1738"/>
+    </location>
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-tycho/0.8.1.201704211436/"/>
+      <unit id="org.sonatype.tycho.m2e.feature.feature.group" version="0.8.1.201704211436"/>
     </location>
 
     <!-- SimRel -->
@@ -329,6 +333,58 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20170306214312/"/>
+      <!-- Eclipse Docker Tooling deps -->
+      <unit id="com.github.jnr.constants" version="0.9.1.v20161107-2054"/>
+      <unit id="com.github.jnr.jffi" version="1.2.11.v20170113-1843"/>
+      <unit id="com.kenai.jffi" version="1.2.7.v201505052040"/>
+      <unit id="org.objectweb.asm" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.analysis" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.tree" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.util" version="5.2.0.v20170126-0011"/>
+      <unit id="org.glassfish.jersey.ext.entityfiltering" version="2.22.1.v20161103-0227"/>
+      <unit id="org.glassfish.jersey.core.jersey-server" version="2.22.1.v20161103-1916"/>
+    </location>
+
+    <!-- Eclipse Docker Tooling -->
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.3.0.201704251823/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.3.0.201704251823"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.3.0.201704251823"/>
+      <!-- Eclipse Docker Tooling deps -->
+      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.5.0.v201504171603"/>
+      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.5.0.v201504171603"/>
+      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
+      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
+      <unit id="javassist" version="3.13.0.GA_v201209210905"/>
+      <unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
+      <unit id="jnr.enxio" version="0.6.0.v201505052040"/>
+      <unit id="jnr.ffi" version="2.0.1.v201505052040"/>
+      <unit id="jnr.posix" version="3.0.9.v201505052040"/>
+      <unit id="jnr.unixsocket" version="0.5.0.v201505052040"/>
+      <unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
+      <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
+      <unit id="org.apache.commons.compress" version="1.6.0.v201310281400"/>
+      <unit id="org.bouncycastle.bcpkix" version="1.52.0.v20160915-1535"/>
+      <unit id="org.bouncycastle.bcprov" version="1.52.0.v20160915-1535"/>
+      <unit id="org.glassfish.hk2.api" version="2.5.0.v20161103-0227"/>
+      <unit id="org.glassfish.hk2.locator" version="2.5.0.v20161103-0227"/>
+      <unit id="org.glassfish.hk2.osgi-resource-locator" version="2.5.0.v20161103-1916"/>
+      <unit id="org.glassfish.hk2.utils" version="2.5.0.v20160210-1508"/>
+      <unit id="org.glassfish.jersey.apache.connector" version="2.14.0.v201504171603"/>
+      <unit id="org.glassfish.jersey.bundles.repackaged.jersey-guava" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.core.jersey-client" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.core.jersey-common" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.22.1.v20161117-2005"/>
+      <unit id="org.objectweb.asm" version="5.1.0.v20160914-0701"/>
+      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201606032238.neon.rc4/"/>
       <unit id="org.eclipse.launchbar.feature.group" version="2.0.0.201606032238"/>
     </location>
@@ -462,48 +518,6 @@
       <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
     </location>
     
-    <!-- Eclipse Docker Tooling -->
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608310043/"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608310043"/>
-      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
-      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.5.0.v201504171603"/>
-      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.5.0.v201504171603"/>
-      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
-      <unit id="com.kenai.jffi" version="1.2.7.v201505052040"/>
-      <unit id="javassist" version="3.13.0.GA_v201209210905"/>
-      <unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
-      <unit id="jnr.constants" version="0.8.6.v201505052040"/>
-      <unit id="jnr.enxio" version="0.6.0.v201505052040"/>
-      <unit id="jnr.ffi" version="2.0.1.v201505052040"/>
-      <unit id="jnr.posix" version="3.0.9.v201505052040"/>
-      <unit id="jnr.unixsocket" version="0.5.0.v201505052040"/>
-      <unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
-      <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
-      <unit id="org.apache.commons.compress" version="1.6.0.v201310281400"/>
-      <unit id="org.bouncycastle.bcpkix" version="1.51.0.v201505131810"/>
-      <unit id="org.bouncycastle.bcprov" version="1.51.0.v201505131810"/>
-      <unit id="org.glassfish.hk2.api" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.locator" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.osgi-resource-locator" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.utils" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.jersey.apache.connector" version="2.14.0.v201504171603"/>
-      <unit id="org.glassfish.jersey.bundles.repackaged.jersey-guava" version="2.14.0.v201504151636"/>
-      <unit id="org.glassfish.jersey.core.jersey-client" version="2.14.0.v201504211925"/>
-      <unit id="org.glassfish.jersey.core.jersey-common" version="2.14.0.v201504171603"/>
-      <unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.14.0.v201504171603"/>
-      <unit id="org.objectweb.asm" version="4.0.0.v201302062210"/>
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-    </location>
-
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201602250914-RELEASE/"/>

--- a/jbdevstudio/multiple/pom.xml
+++ b/jbdevstudio/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-multiple</artifactId>
 	<name>JBDS Multiple (Composite) Target Platform</name>

--- a/jbdevstudio/pom.xml
+++ b/jbdevstudio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbdevstudio</artifactId>

--- a/jbdevstudio/unified/pom.xml
+++ b/jbdevstudio/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-unified</artifactId>
 	<name>JBDS Unified (Aggregate) Target Platform</name>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.60.3.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.60.3.Final-SNAPSHOT">
   <!-- Pro tip: to convert
       from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
     to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>
@@ -76,10 +76,10 @@
 
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
         <repository location="http://origin-repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/jbosstools-locus/1.6.0.Final/jbosstools-locus-1.6.0.Final-updatesite.zip-unzip/"/>
-		<!-- Only in JBT: Test dependencies -->
+        <!-- Only in JBT: Test dependencies -->
         <unit id="org.jboss.tools.locus.mockito" version="1.9.5.v20131024-0922"/>
         <unit id="org.assertj.core" version="2.1.0"/>
-		<!-- For Jetty websocket 9.2.13 -->
+        <!-- For Jetty websocket 9.2.13 -->
         <unit id="org.apache.aries.util" version="1.1.1"/>
         <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.0.2"/>
     </location>
@@ -114,6 +114,10 @@
       <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.3.2.20161026-1738"/>
       <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.3.2.20161026-1738"/>
       <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.3.2.20161026-1738"/>
+    </location>
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-tycho/0.8.1.201704211436/"/>
+      <unit id="org.sonatype.tycho.m2e.feature.feature.group" version="0.8.1.201704211436"/>
     </location>
 
     <!-- SimRel -->
@@ -327,6 +331,58 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/S20170306214312/"/>
+      <!-- Eclipse Docker Tooling deps -->
+      <unit id="com.github.jnr.constants" version="0.9.1.v20161107-2054"/>
+      <unit id="com.github.jnr.jffi" version="1.2.11.v20170113-1843"/>
+      <unit id="com.kenai.jffi" version="1.2.7.v201505052040"/>
+      <unit id="org.objectweb.asm" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.analysis" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.tree" version="5.2.0.v20170126-0011"/>
+      <unit id="org.objectweb.asm.util" version="5.2.0.v20170126-0011"/>
+      <unit id="org.glassfish.jersey.ext.entityfiltering" version="2.22.1.v20161103-0227"/>
+      <unit id="org.glassfish.jersey.core.jersey-server" version="2.22.1.v20161103-1916"/>
+    </location>
+
+    <!-- Eclipse Docker Tooling -->
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.3.0.201704251823/"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.3.0.201704251823"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.3.0.201704251823"/>
+      <!-- Eclipse Docker Tooling deps -->
+      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.5.0.v201504151636"/>
+      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.5.0.v201504171603"/>
+      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.5.0.v201504171603"/>
+      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
+      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
+      <unit id="javassist" version="3.13.0.GA_v201209210905"/>
+      <unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
+      <unit id="jnr.enxio" version="0.6.0.v201505052040"/>
+      <unit id="jnr.ffi" version="2.0.1.v201505052040"/>
+      <unit id="jnr.posix" version="3.0.9.v201505052040"/>
+      <unit id="jnr.unixsocket" version="0.5.0.v201505052040"/>
+      <unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
+      <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
+      <unit id="org.apache.commons.compress" version="1.6.0.v201310281400"/>
+      <unit id="org.bouncycastle.bcpkix" version="1.52.0.v20160915-1535"/>
+      <unit id="org.bouncycastle.bcprov" version="1.52.0.v20160915-1535"/>
+      <unit id="org.glassfish.hk2.api" version="2.5.0.v20161103-0227"/>
+      <unit id="org.glassfish.hk2.locator" version="2.5.0.v20161103-0227"/>
+      <unit id="org.glassfish.hk2.osgi-resource-locator" version="2.5.0.v20161103-1916"/>
+      <unit id="org.glassfish.hk2.utils" version="2.5.0.v20160210-1508"/>
+      <unit id="org.glassfish.jersey.apache.connector" version="2.14.0.v201504171603"/>
+      <unit id="org.glassfish.jersey.bundles.repackaged.jersey-guava" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.core.jersey-client" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.core.jersey-common" version="2.22.1.v20161103-1916"/>
+      <unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.22.1.v20161117-2005"/>
+      <unit id="org.objectweb.asm" version="5.1.0.v20160914-0701"/>
+      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/launchbar/2.0.0.201606032238.neon.rc4/"/>
       <unit id="org.eclipse.launchbar.feature.group" version="2.0.0.201606032238"/>
     </location>
@@ -477,48 +533,6 @@
       <unit id="org.eclipse.egit.ui.smartimport" version="4.4.0.201606011500-rc2"/>
     </location> -->
     
-    <!-- Eclipse Docker Tooling -->
-    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/2.1.0.201608310043/"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.core" version="2.1.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.docs" version="2.0.0.201608310043"/>
-      <unit id="org.eclipse.linuxtools.docker.ui" version="2.1.0.201608310043"/>
-      <unit id="com.spotify.docker.client" version="3.4.0.v20160411-1914"/>
-      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.datatype.jackson-datatype-guava" version="2.5.0.v201504151636"/>
-      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.5.0.v201504171603"/>
-      <unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.5.0.v201504171603"/>
-      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
-      <unit id="com.kenai.jffi" version="1.2.7.v201505052040"/>
-      <unit id="javassist" version="3.13.0.GA_v201209210905"/>
-      <unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
-      <unit id="jnr.constants" version="0.8.6.v201505052040"/>
-      <unit id="jnr.enxio" version="0.6.0.v201505052040"/>
-      <unit id="jnr.ffi" version="2.0.1.v201505052040"/>
-      <unit id="jnr.posix" version="3.0.9.v201505052040"/>
-      <unit id="jnr.unixsocket" version="0.5.0.v201505052040"/>
-      <unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
-      <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
-      <unit id="org.apache.commons.compress" version="1.6.0.v201310281400"/>
-      <unit id="org.bouncycastle.bcpkix" version="1.51.0.v201505131810"/>
-      <unit id="org.bouncycastle.bcprov" version="1.51.0.v201505131810"/>
-      <unit id="org.glassfish.hk2.api" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.locator" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.osgi-resource-locator" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.hk2.utils" version="2.3.0.b10_v201508191500"/>
-      <unit id="org.glassfish.jersey.apache.connector" version="2.14.0.v201504171603"/>
-      <unit id="org.glassfish.jersey.bundles.repackaged.jersey-guava" version="2.14.0.v201504151636"/>
-      <unit id="org.glassfish.jersey.core.jersey-client" version="2.14.0.v201504211925"/>
-      <unit id="org.glassfish.jersey.core.jersey-common" version="2.14.0.v201504171603"/>
-      <unit id="org.glassfish.jersey.media.jersey-media-json-jackson" version="2.14.0.v201504171603"/>
-      <unit id="org.objectweb.asm" version="4.0.0.v201302062210"/>
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-    </location>
-
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.7.3.201602250914-RELEASE/"/>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.60.3.AM1-SNAPSHOT</version>
+		<version>4.60.3.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.60.3.AM1-SNAPSHOT</version>
+	<version>4.60.3.Final-SNAPSHOT</version>
 	<name>JBoss Tools + JBDS Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
JBIDE-24382 bump up to latest docker tooling 2.3.0.20170425 + deps, and also include latest m2e.tycho 0.8.1.201704211436

Signed-off-by: nickboldt <nboldt@redhat.com>