### PR TITLE
JBIDE-24648 JBIDE-24652 JBIDE-24654 bump...

### DIFF
--- a/jbdevstudio/multiple/jbdevstudio-multiple.target
+++ b/jbdevstudio/multiple/jbdevstudio-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbdevstudiotarget-4.70.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbdevstudiotarget-4.70.0.Final-SNAPSHOT">
   <locations>
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 
@@ -441,25 +441,25 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.5.v20170502/"/>
-      <unit id="org.eclipse.jetty.client" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.io" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.security" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.xml" version="9.4.5.v20170502"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.6.v20170531/"/>
+      <unit id="org.eclipse.jetty.client" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.io" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.security" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.xml" version="9.4.6.v20170531"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
@@ -541,8 +541,8 @@
       <unit id="org.jboss.reddeer.ui.feature.feature.group" version="1.2.2.201706191328"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/3.0.0.201705171707/"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="3.0.0.201705171707"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/3.1.0.201708010032/"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="3.1.0.201708010032"/>
     </location>
 
     <!-- JBIDE-19045 move Tern into JST project, so no longer in target platform -->

--- a/jbdevstudio/multiple/pom.xml
+++ b/jbdevstudio/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-multiple</artifactId>
 	<name>Devstudio Multiple (Composite) Target Platform</name>

--- a/jbdevstudio/pom.xml
+++ b/jbdevstudio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbdevstudio</artifactId>

--- a/jbdevstudio/unified/pom.xml
+++ b/jbdevstudio/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbdevstudio</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbdevstudio-unified</artifactId>
 	<name>Devstudio Unified (Aggregate) Target Platform</name>

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.70.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.70.0.Final-SNAPSHOT">
   <locations>
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 
@@ -441,25 +441,25 @@
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.5.v20170502/"/>
-      <unit id="org.eclipse.jetty.client" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.io" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.security" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.5.v20170502"/>
-      <unit id="org.eclipse.jetty.xml" version="9.4.5.v20170502"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.6.v20170531/"/>
+      <unit id="org.eclipse.jetty.client" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.io" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.security" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.6.v20170531"/>
+      <unit id="org.eclipse.jetty.xml" version="9.4.6.v20170531"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
@@ -541,8 +541,8 @@
       <unit id="org.jboss.reddeer.ui.feature.feature.group" version="1.2.2.201706191328"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/3.0.0.201705171707/"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="3.0.0.201705171707"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/3.1.0.201708010032/"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="3.1.0.201708010032"/>
     </location>
 
     <!-- JBIDE-19045 move Tern into JST project, so no longer in target platform -->

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.70.0.AM1-SNAPSHOT</version>
+		<version>4.70.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.70.0.AM1-SNAPSHOT</version>
+	<version>4.70.0.Final-SNAPSHOT</version>
 	<name>JBoss Tools + Devstudio Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
JBIDE-24648 JBIDE-24652 JBIDE-24654 bump version from 4.70.0.AM1-SNAPSHOT to 4.70.0.Final-SNAPSHOT; add Jetty 9.4.6.v20170531; bump up to latest docker 3.1.0.201708010032

Signed-off-by: nickboldt <nboldt@redhat.com>