### PR TITLE
JBIDE-26563 - revert upgrade of tycho m2e

### DIFF
--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -189,8 +189,8 @@
       <unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.17.2.201606141937-signed-20160830073346"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-tycho/0.9.0.201811261502/"/>
-      <unit id="org.sonatype.tycho.m2e.feature.feature.group" version="0.9.0.201811261502"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-tycho/0.8.1.201704211436/"/>
+      <unit id="org.sonatype.tycho.m2e.feature.feature.group" version="0.8.1.201704211436"/>
     </location>
 
     <!-- SimRel -->


### PR DESCRIPTION
the version 0.9.0 of org.sonatype.tycho.m2e contains a regression

Signed-off-by: Aurélien Pupier <apupier@redhat.com>