### PR TITLE
JBIDE-26842 : Update 4.13.0.Final Target Platform for 2019-09.GA

### DIFF
--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.13.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.13.0.Final-SNAPSHOT">
   <locations>
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 	
@@ -194,7 +194,7 @@
 
     <!-- SimRel -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/simrel/20190906-1000-Simrel.2019-09.RC1/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/simrel/20190918-1001-Simrel.2019-09/"/>
 
       <!-- p2.discovery -->
       <unit id="org.eclipse.equinox.p2.discovery" version="1.1.200.v20190611-1008"/>
@@ -236,18 +236,18 @@
 
       <!-- Platform: CVS, JDT, RCP, PDE, Equinox, Help -->
       <!-- <unit id="com.ibm.icu.base" version="56.1.0.v201601250100"/> -->
-      <unit id="org.eclipse.cvs.feature.group" version="1.4.1000.v20190828-1800"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.500.v20190715-1310"/>
+      <unit id="org.eclipse.cvs.feature.group" version="1.4.1000.v20190916-1045"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.500.v20190907-0428"/>
       <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.300.v20190716-0825"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.500.v20190815-1535"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.500.v20190903-0934"/>
       <!-- <unit id="org.eclipse.equinox.http.registry" version="1.1.500.v20171221-2204"/> -->
-      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.11.0.v20190820-2054"/>
+      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.11.0.v20190830-1434"/>
       <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.10.0.v20190823-1423"/>
-      <unit id="org.eclipse.help.feature.group" version="2.2.700.v20190828-1800"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.18.100.v20190828-1800"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.14.100.v20190828-1800"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.13.0.v20190828-1802"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.13.0.v20190828-1802"/>
+      <unit id="org.eclipse.help.feature.group" version="2.2.700.v20190916-1045"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.18.100.v20190916-1045"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.14.100.v20190916-1045"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.13.0.v20190916-1323"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.13.0.v20190916-1045"/>
 
       <!-- needed for JBoss Central -->
       <unit id="org.eclipse.compare" version="3.7.700.v20190802-1838"/>
@@ -262,8 +262,8 @@
       <unit id="org.eclipse.ui" version="3.114.0.v20190808-1317"/>
       <unit id="org.eclipse.ui.editors" version="3.12.0.v20190730-1840"/>
       <unit id="org.eclipse.ui.forms" version="3.8.100.v20190625-1825"/>
-      <unit id="org.eclipse.ui.ide" version="3.16.0.v20190826-1312"/>
-      <unit id="org.eclipse.ui.workbench.texteditor" version="3.13.0.v20190730-1840"/>
+      <unit id="org.eclipse.ui.ide" version="3.16.0.v20190916-1323"/>
+      <unit id="org.eclipse.ui.workbench.texteditor" version="3.13.0.v20190903-0631"/>
       <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
 
       <!-- Zest -->
@@ -272,16 +272,16 @@
       <unit id="org.eclipse.zest.feature.group" version="1.7.0.201606061308"/>
 
       <!-- Graphiti required by JBoss Fuse Tooling -->
-      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.doc" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.export.batik" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.mm" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.pattern" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.tools.newprojectwizard" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.ui" version="0.16.1.201908161231"/>
-      <unit id="org.eclipse.graphiti.ui.capabilities" version="0.16.1.201908161231"/>
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.doc" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.export.batik" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.mm" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.pattern" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.tools.newprojectwizard" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.ui" version="0.16.1.201909061426"/>
+      <unit id="org.eclipse.graphiti.ui.capabilities" version="0.16.1.201909061426"/>
       <unit id="org.w3c.css.sac" version="1.3.1.v200903091627"/>
       <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
 
@@ -317,10 +317,11 @@
       <unit id="org.apache.lucene.analyzers-common" version="6.1.0.v20161115-1612"/>
 
       <!-- egit -->
-      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.5.0.201909041048-rc1"/>
-      <unit id="org.eclipse.egit.feature.group" version="5.5.0.201909041048-rc1"/>
-      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.5.0.201909041048-rc1"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.5.0.201909041048-rc1"/>
+      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.5.0.201909110433-r"/>
+      <unit id="org.eclipse.egit.feature.group" version="5.5.0.201909110433-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.5.0.201909110433-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.5.0.201909110433-r"/>
+      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.5.0.201909110433-r"/>
 
     </location>
 
@@ -354,17 +355,10 @@
 
     </location>
 
-    <!-- Mylyn Github moved out from SimRel as of 2018-12M3 -->
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mylyn-github/5.5.0.201909041048/"/>
-      <!-- mylyn github -->
-      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.5.0.201909041048-rc1"/>
-    </location>
-
     <!-- Complete JGit, see https://issues.jboss.org/browse/JBIDE-26815-->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jgit/5.5.0.201909041048-rc1/"/>
-      <unit id="org.eclipse.jgit.junit" version="5.5.0.201909041048-rc1"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/jgit/5.5.0.201909110433-r/"/>
+      <unit id="org.eclipse.jgit.junit" version="5.5.0.201909110433-r"/>
     </location>
 
     <!-- pull newer mylyn stuff than what's in simrel, so we have the same version as in Nodeclipse. This lets the install test job pass in 
@@ -623,10 +617,10 @@
 
     <!-- Eclipse Docker Tooling (see Orbit section above for dependencies) -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/4.4.0.201909060401/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.4.0.201909060401"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.4.0.201909060401"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.4.0.201909060401"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/docker/4.4.0.201909110158/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.4.0.201909110158"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.4.0.201909110158"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.4.0.201909110158"/>
       <unit id="org.mockito" version="2.23.0.v20190527-1420"/>
     </location>
 
@@ -642,25 +636,25 @@
 
     <!-- Reddeer -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/reddeer/2.7.0.RC1/"/>
-      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.selenium.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.7.0.v20190904-1826"/>
-      <unit id="org.eclipse.reddeer.jdt.junit" version="2.7.0.v20190904-1826"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/reddeer/2.7.0/"/>
+      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.selenium.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.7.0.v20190911-1936"/>
+      <unit id="org.eclipse.reddeer.jdt.junit" version="2.7.0.v20190911-1936"/>
     </location>
 
     <!-- LSP4E -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.11.0.201908201332/"/>
-      <unit id="org.eclipse.lsp4e" version="0.11.0.201908201332"/>
+       <repository location="http://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.11.0.201909090701/"/>
+      <unit id="org.eclipse.lsp4e" version="0.11.0.201909090701"/>
       <unit id="org.eclipse.lsp4j" version="0.7.2.v20190528-0933"/>
       <unit id="org.eclipse.lsp4j.jsonrpc" version="0.7.2.v20190528-0933"/>
       <unit id="org.eclipse.xtext.xbase.lib" version="2.18.0.v20190603-0326"/>
@@ -682,8 +676,8 @@
 
     <!-- JBIDE-25979 Apache Camel Language Server -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.201908230805/camel-lsp-client-eclipse-update-site-master/updatesite/nightly/"/>
-      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.201908230805"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.201909171309/camel-lsp-client-eclipse-update-site-master/updatesite/nightly/"/>
+      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.201909171309"/>
     </location>
 
   </locations>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.13.0.AM1-SNAPSHOT</version>
+		<version>4.13.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.13.0.AM1-SNAPSHOT</version>
+		<version>4.13.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.13.0.AM1-SNAPSHOT</version>
+		<version>4.13.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.13.0.AM1-SNAPSHOT</version>
+	<version>4.13.0.Final-SNAPSHOT</version>
 	<name>JBoss Tools + Devstudio Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
Bump to 4.13.0.Final version
Added Simrel 2019-09
Added JGit 5.5.0.201909110433-r
Added Docker Tooling 4.4.0.201909110158
Added Reddeer 2.7.0
Added LSP4E 0.11.0.201909090701
Added CamelTooling 1.0.0.201909171309

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>