### PR TITLE
JBIDE-27089 : Update 4.15.0.AM1 Target Platform for 2020-03.GA

### DIFF
--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.14.0.Final-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.15.0.AM1-SNAPSHOT">
   <locations>
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 	

--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -5,7 +5,7 @@
 	
 	
 	<location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/orbit/R20191126223242"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/orbit/R20200224183213"/>
       
       <!-- livereload requires org.apache.aries.spifly.dynamic.bundle 1.0.10, which requires
            org.objectweb.asm.commons [5.0.0,7)' -->
@@ -17,8 +17,7 @@
 
       <!-- for these IUs we need multiple versions -->
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/> <!-- needed by m2e 1.13.0.20190716-1624 -->
-      <unit id="org.apache.lucene.core" version="8.0.0.v20190404-1858"/>
-      <unit id="org.apache.lucene.misc" version="8.0.0.v20190418-1455"/> <!-- needed by org.eclipse.reddeer.eclipse.test 2.6.0.v20190612-1247 -->
+      <unit id="org.apache.lucene.core" version="8.4.1.v20200122-1459"/>
       <unit id="org.apache.lucene.core" version="7.5.0.v20181003-1532"/>
       <unit id="org.apache.lucene.misc" version="7.5.0.v20181003-1532"/>
       <unit id="org.apache.lucene.analyzers-common" version="7.5.0.v20181003-1532"/>
@@ -27,8 +26,8 @@
 
       <!-- qos.logback 1.1.2 requires org.slf4j.spi [1.7.10,1.8.0) -->
       <unit id="ch.qos.logback.classic" version="1.1.2.v20171220-1825"/> 
-      <unit id="ch.qos.logback.core" version="1.1.2.v20160208-0839"/>
-      <unit id="org.slf4j.api" version="1.7.10.v20170428-1633"/>
+      <unit id="ch.qos.logback.core" version="1.1.2.v20200204-2150"/>
+      <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
 
       <!-- Orbit bundles -->
       <unit id="javax.wsdl" version="1.6.2.v201012040545"/>
@@ -69,8 +68,8 @@
       <unit id="org.apache.maven.resolver.transport.file" version="1.0.3.v20170405-0725"/>
       <unit id="org.apache.maven.resolver.transport.http" version="1.0.3.v20170405-0725"/>
       <unit id="org.apache.maven.resolver.util" version="1.0.3.v20170405-0725"/>
-      <unit id="org.apache.httpcomponents.httpcore" version="4.4.10.v20190123-2214"/>
-      <unit id="org.apache.httpcomponents.httpclient" version="4.5.6.v20190503-0009"/>
+      <unit id="org.apache.httpcomponents.httpcore" version="4.4.12.v20200108-1212"/>
+      <unit id="org.apache.httpcomponents.httpclient" version="4.5.10.v20200114-1512"/>
       <unit id="org.apache.commons.logging" version="1.2.0.v20180409-1502"/>
 
       <!-- Needed by jbosstools-aerogear, also wtp -->
@@ -118,7 +117,7 @@
       <unit id="javax.ws.rs" version="2.0.1.v201504171603"/>
       <unit id="jnr.x86asm" version="1.0.2.v201505052040"/>
       <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
-      <unit id="org.apache.commons.compress" version="1.15.0.v20180119-1613"/>
+      <unit id="org.apache.commons.compress" version="1.19.0.v20200106-2343"/>
       <unit id="org.bouncycastle.bcpkix" version="1.61.0.v20190602-1335"/>
       <unit id="org.bouncycastle.bcprov" version="1.61.0.v20190602-1335"/>
       <unit id="org.glassfish.hk2.api" version="2.5.0.v20161103-0227"/>
@@ -160,7 +159,6 @@
         <unit id="org.jboss.tools.locus.mockito" version="1.9.5.v20131024-0922"/>
         <unit id="org.assertj.core" version="2.1.0"/>
         <!-- For Jetty websocket 9.2.13 -->
-        <!--<unit id="org.apache.aries.util" version="1.1.3"/>-->
         <unit id="org.apache.aries.spifly.dynamic.bundle" version="1.2.0"/>
         <!-- For Fuse Tooling -->
         <unit id="org.jboss.tools.locus.jsonschema2pojo.jsonschema2pojo-core" version="0.4.13.v20160122-1745"/>
@@ -171,14 +169,14 @@
 
     <!-- m2e family, not included in SimRel site (or newer versions); see also simrel site below, and Central TP for more -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/m2e/1.14.0.20191209-1925/"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.14.0.20191209-1925"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.14.0.20191209-1925"/>
-      <unit id="org.eclipse.m2e.importer" version="1.14.0.20191209-1925"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/m2e/1.15.0.20200310-1746/"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.15.0.20200310-1832"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.15.0.20200109-0905"/>
+      <unit id="org.eclipse.m2e.importer" version="1.15.0.20200109-0905"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.2-2018-12-24_15-46-05-H18/"/>
-      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.5.2.201812241535"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>
+      <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.5.3.201911081053"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
       <repository location="https://download.jboss.org/jbosstools/updates/requirements/m2e-buildhelper/0.15.0.201405280027/"/>
@@ -200,39 +198,39 @@
 
     <!-- SimRel -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/simrel/20191218-1000-Simrel.2019-12/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/simrel/20200318-1000-Simrel.2020-03/"/>
 
       <!-- p2.discovery -->
       <unit id="org.eclipse.equinox.p2.discovery" version="1.1.200.v20190611-1008"/>
       <unit id="org.eclipse.equinox.p2.discovery.compatibility" version="1.1.200.v20190611-1008"/>
-      <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.1.300.v20191014-1907"/>
+      <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.1.400.v20191213-1911"/>
 
       <!-- ECF -->
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.5.400.v20191023-2007"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.5.500.v20200217-1548"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.300.v20191023-2007"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.600.v20191023-2007"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group" version="1.0.100.v20191024-1546"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.700.v20200217-0016"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group" version="1.0.300.v20200217-0016"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.200.v20191024-1546"/>
-      <unit id="org.eclipse.equinox.concurrent" version="1.1.400.v20190621-0852"/>
+      <unit id="org.eclipse.equinox.concurrent" version="1.1.500.v20200106-1437"/>
 
       <!-- EMF, XSD -->
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.20.0.v20191012-0918"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.21.0.v20200112-0705"/>
       <unit id="org.eclipse.emf.codegen.feature.group" version="2.19.0.v20190821-1536"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.17.0.v20190920-0401"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.18.0.v20191225-1014"/>
       <unit id="org.eclipse.emf.databinding.feature.group" version="1.7.0.v20190323-1059"/>
       <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.14.0.v20190822-1451"/>
       <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.17.0.v20190528-0725"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.20.0.v20190920-0401"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.20.0.v20190920-0401"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.21.0.v20200127-1342"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.21.0.v20200127-1342"/>
       <unit id="org.eclipse.emf.edit.feature.group" version="2.16.0.v20190920-0401"/>
-      <unit id="org.eclipse.emf.feature.group" version="2.20.0.v20191028-0905"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.21.0.v20200205-0529"/>
       <unit id="org.eclipse.emf.transaction.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.emf.validation.feature.group" version="1.12.1.201812070911"/>
       <unit id="org.eclipse.emf.workspace.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.12.0.v20190323-1100"/>
       <unit id="org.eclipse.xsd.edit.feature.group" version="2.12.0.v20190323-1100"/>
       <unit id="org.eclipse.xsd.editor.feature.group" version="2.13.0.v20190323-1100"/>
-      <unit id="org.eclipse.xsd.feature.group" version="2.18.0.v20191117-1035"/>
+      <unit id="org.eclipse.xsd.feature.group" version="2.18.0.v20191220-1010"/>
       <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.13.0.v20190323-1100"/>
       <unit id="org.eclipse.xsd.mapping.feature.group" version="2.12.0.v20190323-1100"/>
 
@@ -241,32 +239,31 @@
       <unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
 
       <!-- Platform: CVS, JDT, RCP, PDE, Equinox, Help -->
-      <unit id="org.eclipse.cvs.feature.group" version="1.4.1200.v20191210-0610"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.600.v20191014-2025"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.400.v20191014-1907"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.600.v20191120-0247"/>
-      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.12.0.v20191122-2104"/>
-      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.10.100.v20191122-1941"/>
-      <unit id="org.eclipse.help.feature.group" version="2.3.0.v20191210-0610"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.18.200.v20191210-0610"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.14.200.v20191210-0610"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.14.0.v20191210-0610"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.14.0.v20191210-0610"/>
+      <unit id="org.eclipse.cvs.feature.group" version="1.4.1300.v20200305-0155"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.700.v20200207-2156"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.500.v20191213-1911"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.700.v20200222-1600"/>
+      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.12.100.v20200214-1600"/>
+      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.10.200.v20200303-1901"/>
+      <unit id="org.eclipse.help.feature.group" version="2.3.100.v20200305-0155"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.18.300.v20200305-0155"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.14.300.v20200305-0155"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.15.0.v20200305-0155"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.15.0.v20200305-0155"/>
 
       <!-- needed for JBoss Central -->
-      <unit id="org.eclipse.compare" version="3.7.800.v20191122-2107"/>
-      <unit id="org.eclipse.core.filesystem" version="1.7.600.v20191122-2104"/>
-      <unit id="org.eclipse.core.resources" version="3.13.600.v20191122-2104"/>
-      <unit id="org.eclipse.epp.logging.aeri.feature.feature.group" version="2.0.7.v20180504-0806"/>
-      <unit id="org.eclipse.jface" version="3.18.0.v20191122-2109"/>
-      <unit id="org.eclipse.jface.text" version="3.16.100.v20191203-1634"/>
-      <unit id="org.eclipse.team.core" version="3.8.800.v20191122-2107"/>
-      <unit id="org.eclipse.team.ui" version="3.8.700.v20191122-2107"/>
-      <unit id="org.eclipse.ui" version="3.115.0.v20191127-1056"/>
-      <unit id="org.eclipse.ui.editors" version="3.13.0.v20191203-1122"/>
-      <unit id="org.eclipse.ui.forms" version="3.8.200.v20191114-0830"/>
-      <unit id="org.eclipse.ui.ide" version="3.16.100.v20191122-2109"/>
-      <unit id="org.eclipse.ui.workbench.texteditor" version="3.14.0.v20191122-2108"/>
+      <unit id="org.eclipse.compare" version="3.7.900.v20200129-0902"/>
+      <unit id="org.eclipse.core.filesystem" version="1.7.700.v20200110-1734"/>
+      <unit id="org.eclipse.core.resources" version="3.13.700.v20200209-1624"/>
+      <unit id="org.eclipse.jface" version="3.19.0.v20200218-1607"/>
+      <unit id="org.eclipse.jface.text" version="3.16.200.v20200218-0828"/>
+      <unit id="org.eclipse.team.core" version="3.8.900.v20200211-0946"/>
+      <unit id="org.eclipse.team.ui" version="3.8.800.v20200211-0752"/>
+      <unit id="org.eclipse.ui" version="3.116.0.v20200203-1308"/>
+      <unit id="org.eclipse.ui.editors" version="3.13.100.v20200130-1507"/>
+      <unit id="org.eclipse.ui.forms" version="3.9.0.v20200213-1442"/>
+      <unit id="org.eclipse.ui.ide" version="3.17.0.v20200217-1511"/>
+      <unit id="org.eclipse.ui.workbench.texteditor" version="3.14.100.v20200212-1049"/>
       <unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
 
       <!-- Zest -->
@@ -295,24 +292,17 @@
       <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
       <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
 
-      <!-- Buildship -->
-      <unit id="org.eclipse.buildship.feature.group" version="3.1.3.v20191118-1057"/>
-      <unit id="org.gradle.toolingapi" version="6.0.0.v20191118-1057"/>
-
-      <unit id="org.eclipse.remote.core" version="4.0.0.201909031456"/>
-      <unit id="org.eclipse.remote.ui" version="2.1.1.201909031456"/>
-
       <!-- m2e.wtp -->
-      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.3.20191209-1849"/>
-      <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.4.3.20191209-1849"/>
-      <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.4.3.20191209-1849"/>
-      <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.4.3.20191209-1849"/>
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.4.20200220-1005"/>
+      <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.4.4.20200220-1005"/>
+      <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.4.4.20200220-1005"/>
+      <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.4.4.20200220-1005"/>
 
       <!-- launchbar -->
-      <unit id="org.eclipse.launchbar.feature.group" version="2.4.1.201911192211"/>
+      <unit id="org.eclipse.launchbar.feature.group" version="2.4.100.202001141724"/>
 
       <!-- mylyn docs / extras -->
-      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="3.0.35.201912061959"/>
+      <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="3.0.36.202002070035"/>
 
       <!-- needed by mylyn 3.25.0-->
       <unit id="org.apache.lucene.core" version="6.1.0.v20170814-1820"/>
@@ -320,12 +310,12 @@
       <unit id="org.apache.lucene.analyzers-common" version="6.1.0.v20161115-1612"/>
 
       <!-- egit -->
-      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.jgit.http.apache.feature.group" version="5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.6.0.201912101111-r"/>
+      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.egit.feature.group" version="5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.7.0.202003110725-r"/>
 
      <!-- TM4E required by dockertools and wild web developer-->
      <unit id="org.eclipse.tm4e.registry" version="0.4.0.201911130739"/>
@@ -355,10 +345,17 @@
 
     </location>
 
+    <!-- Buildship (for sources)-->
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/buildship/3.1.3.v20191118-1057/"/>
+      <unit id="org.eclipse.buildship.feature.group" version="3.1.3.v20191118-1057"/>
+      <unit id="org.gradle.toolingapi" version="6.0.0.v20191118-1057"/>
+    </location>
+
     <!-- Complete JGit, see https://issues.jboss.org/browse/JBIDE-26815-->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jgit/5.6.0.201912101111-r"/>
-      <unit id="org.eclipse.jgit.junit" version="5.6.0.201912101111-r"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jgit/5.7.0.202003110725-r"/>
+      <unit id="org.eclipse.jgit.junit" version="5.7.0.202003110725-r"/>
     </location>
 
     <!-- pull newer mylyn stuff than what's in simrel, so we have the same version as in Nodeclipse. This lets the install test job pass in 
@@ -434,60 +431,64 @@
       <unit id="org.eclipse.gemini.management" version="2.0.0.RELEASE"/>
     </location>
 
-    <!-- TODO: merge TM.Terminal and RSE builds and upversion stuff -->
-    <!-- TM and RSE are in Simrel but this way we get sources too -->
+    <!-- RSE -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/tm/4.5.102.201911240504/"/>
-      <unit id="org.eclipse.rse.terminals.feature.group" version="4.5.100.201911240504"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/tm/4.5.200.201901312252/"/>
+      <unit id="org.eclipse.rse.terminals.feature.group" version="4.5.100.202002061858"/>
       <unit id="org.eclipse.rse.connectorservice.ssh" version="4.5.100.201901312252"/>
       <unit id="org.eclipse.rse.core" version="4.5.100.201901312252"/>
       <unit id="org.eclipse.rse.services" version="4.5.100.201901312252"/>
       <unit id="org.eclipse.rse.services.ssh" version="4.5.100.201901312252"/>
       <unit id="org.eclipse.rse.ui" version="4.5.100.201901312252"/>
 
-      <unit id="org.eclipse.rse.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.rse.ftp.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.rse.local.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.rse.ssh.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.rse.telnet.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.rse.useractions.feature.group" version="4.5.100.201911240504"/>
+      <unit id="org.eclipse.rse.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.ftp.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.local.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.ssh.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.telnet.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.useractions.feature.group" version="4.5.100.202002061858"/>
 
-      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.5.100.201911240504"/>
-      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.5.102.201911240504"/>
-      <unit id="org.eclipse.tm.terminal.view.core" version="4.5.100.201901312304"/>
-      <unit id="org.eclipse.tm.terminal.view.ui" version="4.5.200.201911231043"/>
       <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.5.100.201901312304"/>
-      <unit id="org.eclipse.cdt.native.feature.group" version="9.7.0.201901082014"/>
+    </location>
+
+    <!-- TM is now part of CDT-->
+    <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/cdt/9.11/"/>
+      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="4.6.0.202002152032"/>
+      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="4.6.0.202001311822"/>
+      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="4.6.0.202002151945"/>
+      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="4.6.0.202002152037"/>
+      <unit id="org.eclipse.tm.terminal.view.core" version="4.6.0.202002142109"/>
+      <unit id="org.eclipse.tm.terminal.view.ui" version="4.6.0.202002151945"/>
+      <unit id="org.eclipse.cdt.native.feature.group" version="9.11.0.202002181755"/>
     </location>
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.25.v20191220/"/>
-      <unit id="org.eclipse.jetty.client" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.io" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.security" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.25.v20191220"/>
-      <unit id="org.eclipse.jetty.xml" version="9.4.25.v20191220"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.27.v20200227/"/>
+      <unit id="org.eclipse.jetty.client" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.io" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.security" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.27.v20200227"/>
+      <unit id="org.eclipse.jetty.xml" version="9.4.27.v20200227"/>
     </location>
 
     <!-- Web Tools -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/webtools/R-3.16.0-20191210070716/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/webtools/R-3.17.0-20200306035042/"/>
       <unit id="org.eclipse.jem" version="2.0.600.v201903222024"/>
       <unit id="org.eclipse.jem.beaninfo" version="2.0.300.v201903222024"/>
       <unit id="org.eclipse.jem.beaninfo.vm" version="2.0.300.v201903222024"/>
@@ -499,7 +500,7 @@
       <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.5.100.v201903221940"/>
       <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.100.v201903221940"/>
       <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.101.v201903221940"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.5.101.v201903221940"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.6.0.v202002052252"/>
       <unit id="org.eclipse.jsf.feature.feature.group" version="3.10.0.v201902121810"/>
       <unit id="org.eclipse.jst.common.annotations.controller" version="1.1.300.v201903222024"/>
       <unit id="org.eclipse.jst.common.annotations.core" version="1.1.300.v201903222024"/>
@@ -584,8 +585,8 @@
       <unit id="org.eclipse.wst.common_core.feature.feature.group" version="3.10.100.v201904082145"/>
       <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.11.0.v201905071717"/>
       <unit id="org.eclipse.wst.jsdt.chromium.debug.feature.feature.group" version="0.6.100.v201908270117"/>
-      <unit id="org.eclipse.wst.jsdt.debug.rhino.ui" version="1.0.500.v201903222047"/>
-      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.1.4.v201912012351"/>
+      <unit id="org.eclipse.wst.jsdt.debug.rhino.ui" version="1.0.600.v202001081921"/>
+      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.1.5.v202002141644"/>
       <unit id="org.eclipse.wst.jsdt.nodejs.feature.feature.group" version="1.1.0.v201908270117"/>
       <unit id="org.eclipse.wst.jsdt.web.support.jsp" version="1.1.0.v201901071922"/>
       <unit id="org.eclipse.wst.json_core.feature.feature.group" version="1.1.8.v201909302219"/>
@@ -594,10 +595,10 @@
       <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.800.v201910252115"/>
       <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.900.v201910252115"/>
       <unit id="org.eclipse.wst.server_userdoc.feature.feature.group" version="3.3.300.v201901310132"/>
-      <unit id="org.eclipse.wst.sse.core" version="1.2.100.v201901310548"/>
-      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.16.0.v201911262147"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.16.0.v201911262315"/>
-      <unit id="org.eclipse.wst.web_userdoc.feature.feature.group" version="3.16.0.v201909302219"/>
+      <unit id="org.eclipse.wst.sse.core" version="1.2.200.v202002172151"/>
+      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.17.0.v202002172151"/>
+      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.17.0.v202002172151"/>
+      <unit id="org.eclipse.wst.web_userdoc.feature.feature.group" version="3.17.0.v202001081257"/>
       <unit id="org.eclipse.wst.ws.explorer" version="1.0.1000.v201910301957"/>
       <unit id="org.eclipse.wst.ws.infopop" version="1.0.400.v201903050508"/>
       <unit id="org.eclipse.wst.ws.service.policy.ui" version="1.0.500.v201903050508"/>
@@ -608,19 +609,19 @@
       <unit id="org.eclipse.wst.wsdl.ui" version="1.3.0.v201910301957"/>
       <unit id="org.eclipse.wst.wsi.ui" version="1.1.0.v201910301957"/>
       <unit id="org.eclipse.wst.xml.xpath2.processor.feature.feature.group" version="2.0.302.v201909031400"/>
-      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.16.0.v201911262147"/>
-      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.16.0.v201911262138"/>
-      <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="3.16.0.v201909302219"/>
+      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.17.0.v202002172151"/>
+      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.17.0.v202001091420"/>
+      <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="3.17.0.v202001081257"/>
       <unit id="org.eclipse.wst.xsl.feature.feature.group" version="1.3.900.v201909031400"/>
       <unit id="com.sun.xml.bind" version="2.2.0.v201505121915"/>
     </location>
 
     <!-- Eclipse Docker Tooling (see Orbit section above for dependencies) -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/4.5.1.202001142113/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.5.1.202001142113"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.5.1.202001142113"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.5.1.202001142113"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/4.6.0.202003102154/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.6.0.202003102154"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.6.0.202003102154"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.6.0.202003102154"/>
       <unit id="org.mockito" version="2.23.0.v20190527-1420"/>
     </location>
 
@@ -636,51 +637,50 @@
 
     <!-- Reddeer -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/reddeer/2.8.0/"/>
-      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.selenium.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.8.0.v20191211-1503"/>
-      <unit id="org.eclipse.reddeer.jdt.junit" version="2.8.0.v20191211-1503"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/reddeer/2.9.0/"/>
+      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.selenium.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="2.9.0.v20200311-1932"/>
+      <unit id="org.eclipse.reddeer.jdt.junit" version="2.9.0.v20200311-1932"/>
     </location>
 
     <!-- LSP4E -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.13.0/"/>
-      <unit id="org.eclipse.lsp4e" version="0.13.0.201912071343"/>
-      <unit id="org.eclipse.lsp4e.debug" version="0.11.0.201911212057"/>
-      <unit id="org.eclipse.lsp4j" version="0.8.1.v20190925-0746"/>
-      <unit id="org.eclipse.lsp4j.debug" version="0.8.1.v20190925-0746"/>
-      <unit id="org.eclipse.lsp4j.jsonrpc" version="0.8.1.v20190925-0746"/>
-      <unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.8.1.v20190925-0746"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.14.0/"/>
+      <unit id="org.eclipse.lsp4e" version="0.13.1.202003021135"/>
+      <unit id="org.eclipse.lsp4e.debug" version="0.12.0.202003021135"/>
+      <unit id="org.eclipse.lsp4j" version="0.9.0.v20200229-1009"/>
+      <unit id="org.eclipse.lsp4j.debug" version="0.9.0.v20200229-1009"/>
+      <unit id="org.eclipse.lsp4j.jsonrpc" version="0.9.0.v20200229-1009"/>
+      <unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.9.0.v20200229-1009"/>
       <unit id="org.eclipse.xtext.xbase.lib" version="2.19.0.v20190902-0728"/>
     </location>
 
     <!-- TestNG -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/testng/7.0.0.201908240652/"/>
-      <unit id="org.testng.eclipse.feature.group" version="7.0.0.201908240652"/>
-      <unit id="org.testng.p2.feature.feature.group" version="7.0.0.r201908191551"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/testng/7.1.1.202003100345/"/>
+      <unit id="org.testng.eclipse.feature.group" version="7.1.1.202003100345"/>
+      <unit id="org.testng.p2.feature.feature.group" version="7.1.0.r202001120626"/>
     </location>
 
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.10.201909171046-RELEASE/"/>
       <unit id="org.dadacoalition.yedit" version="1.0.18.201602092025-RELEASE-SIGNED"/>
-      <unit id="org.yaml.snakeyaml" version="1.14.0.v201604211500"/>
     </location>
 
     <!-- JBIDE-25979 Apache Camel Language Server -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.202001061453/camel-lsp-client-eclipse-update-site-master/updatesite/nightly/"/>
-      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.202001061453"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.202003121347/camel-lsp-client-eclipse-update-site-master/updatesite/nightly/"/>
+      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.202003121347"/>
     </location>
 
     <!-- JBDS-4807 m2e-chromatic -->

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.14.0.Final-SNAPSHOT</version>
+		<version>4.15.0.AM1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.14.0.Final-SNAPSHOT</version>
+		<version>4.15.0.AM1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.14.0.Final-SNAPSHOT</version>
+		<version>4.15.0.AM1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.14.0.Final-SNAPSHOT</version>
+	<version>4.15.0.AM1-SNAPSHOT</version>
 	<name>JBoss Tools + Devstudio Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
updated following bundles/repo:  
testng 7.1.1.202003100345
lsp4e 0.14.0
reddeer 2.9.0
docker 4.6.0.202003102154
webtools R-3.17.0-20200306035042
jetty 9.4.27.v20200227
cdt 9.11 ( TM/RSE split )
tm 4.5.200.201901312252
buildship 3.1.3.v20191118-1057
m2e 1.15.0.20200310-1746
cameltooling 1.0.0.202003121347
jgit 5.6.0.201912101111-r
orbit R20200224183213
simrel 20200318-1000-Simrel.2020-03

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>