### PR TITLE
JBIDE-27327 : Update 4.16.0.Final Target Platform for 2020-06 GA

### DIFF
--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstoolstarget-4.16.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbosstoolstarget-4.16.0.Final-SNAPSHOT">
   <locations>
     <!-- don't forget to increment these files when moving up a version: build.xml, *.target -->
 	
@@ -638,10 +638,10 @@
 
     <!-- Eclipse Docker Tooling (see Orbit section above for dependencies) -->
     <location includeAllPlatforms="false" includeMode="slicer" type="InstallableUnit" includeSource="true">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/4.7.0.202006092019/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.7.0.202006092019"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.7.0.202006092019"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.7.0.202006092019"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/4.7.0.202006252201/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="4.7.0.202006252201"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="4.7.0.202006252201"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="4.7.0.202006252201"/>
     </location>
 
     <!-- SWT Bot -->
@@ -691,7 +691,7 @@
 
     <!-- JBIDE-21377 YAML Editor -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.12.202003180620-RELEASE/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.13.202006180736-RELEASE/"/>
       <unit id="org.dadacoalition.yedit" version="1.0.18.201602092025-RELEASE-SIGNED"/>
     </location>
 
@@ -710,8 +710,8 @@
 
     <!-- Wild Web Developer -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/wildwebdeveloper/0.9.1/"/>
-      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.9.1.202005041657"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/wildwebdeveloper/0.10.0/"/>
+      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.10.0.202006021616"/>
     </location>
 
   </locations>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.16.0.AM1-SNAPSHOT</version>
+		<version>4.16.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-multiple</artifactId>
 	<name>JBoss Tools Multiple (Composite) Target Platform</name>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>root</artifactId>
-		<version>4.16.0.AM1-SNAPSHOT</version>
+		<version>4.16.0.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbosstools/unified/pom.xml
+++ b/jbosstools/unified/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbosstools</artifactId>
-		<version>4.16.0.AM1-SNAPSHOT</version>
+		<version>4.16.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbosstools-unified</artifactId>
 	<name>JBoss Tools Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>root</artifactId>
-	<version>4.16.0.AM1-SNAPSHOT</version>
+	<version>4.16.0.Final-SNAPSHOT</version>
 	<name>JBoss Tools + Devstudio Target Platform Root</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
added linuxtools 4.7.0.202006252201
added wildwebdeveloper 0.10.0
added springide 3.9.13.202006180736-RELEASE

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>