### PR TITLE
JBIDE-27651: Update 4.19.0.AM1 Target Platform for 2021-03

### DIFF
--- a/jbosstools/multiple/jbosstools-multiple.target
+++ b/jbosstools/multiple/jbosstools-multiple.target
@@ -5,13 +5,14 @@
     
     
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/orbit/R20200831200620"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/orbit/R20210223232630/"/>
 
       <!-- Global Orbit bundles required by upstream and/or downstream -->
-      <unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
+      <unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
       <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
+      <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
       <unit id="javax.activation" version="1.1.0.v201211130549"/>
-      <unit id="javax.annotation" version="1.3.5.v20200504-1837"/>
+      <unit id="javax.annotation" version="1.3.5.v20200909-1856"/>
       <unit id="javax.mail" version="1.4.0.v201005080615"/>
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
       <unit id="javax.servlet.jsp" version="2.2.0.v201112011158"/>
@@ -22,7 +23,7 @@
       <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
       <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
       <unit id="org.apache.commons.logging" version="1.2.0.v20180409-1502"/>
-      <unit id="org.apache.httpcomponents.httpcore" version="4.4.12.v20200108-1212"/>
+      <unit id="org.apache.httpcomponents.httpcore" version="4.4.14.v20210128-2225"/>
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
       <unit id="org.apache.lucene.analyzers-smartcn" version="8.4.1.v20200122-1459"/>
       <unit id="org.apache.lucene.core" version="8.4.1.v20200122-1459"/>
@@ -51,7 +52,8 @@
       <unit id="com.google.javascript" version="0.0.20160315.v20161124-1903"/>
       <unit id="com.google.protobuf" version="2.4.0.v201105131100"/>
       <unit id="com.sun.el" version="2.2.0.v201303151357"/>
-      <unit id="com.sun.xml.bind" version="2.2.0.v201505121915"/>
+      <unit id="com.sun.xml.bind" version="2.2.0.v20201118-1845"/>
+      <unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
       <unit id="java_cup.runtime" version="0.10.0.v201005080400"/>
       <unit id="javax.el" version="2.2.0.v201303151357"/>
       <unit id="javax.xml.rpc" version="1.1.0.v201209140446"/>
@@ -72,9 +74,9 @@
       <unit id="org.apache.ws.commons.util" version="1.0.2.v20160817-1930"/>
 
       <!-- required by Docker Tooling -->
-      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.10.3.v20200512-1600"/>
-      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.10.3.v20200512-1600"/>
-      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.10.3.v20200512-1600"/>
+      <unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.12.1.v20210128-1726"/>
+      <unit id="com.fasterxml.jackson.core.jackson-core" version="2.12.1.v20210128-1726"/>
+      <unit id="com.fasterxml.jackson.core.jackson-databind" version="2.12.1.v20210128-1726"/>
       <unit id="com.github.jnr.constants" version="0.9.15.v20200501-1917"/>
       <unit id="com.github.jnr.enxio" version="0.25.0.v20200501-1917"/>
       <unit id="com.github.jnr.ffi" version="2.1.12.v20200513-1859"/>
@@ -92,7 +94,7 @@
       <unit id="io.grpc.grpc-context" version="1.29.0.v20200515-2048"/>
       <unit id="io.opencensus.opencensus-api" version="0.26.0.v20200515-2048"/>
       <unit id="io.opencensus.opencensus-contrib-http-util" version="0.26.0.v20200515-2048"/>
-      <unit id="jakarta.xml.bind" version="2.3.3.v20200525-2159"/>
+      <unit id="jakarta.xml.bind" version="2.3.3.v20201118-1818"/>
       <unit id="javassist" version="3.13.0.GA_v201209210905"/>
       <unit id="javax.ws.rs" version="2.1.6.v20200505-2127"/>
       <unit id="org.aopalliance" version="1.0.0.v201105210816"/>
@@ -114,6 +116,7 @@
       <unit id="org.mandas.docker-client" version="3.2.1.v20200519-1937"/>
       <unit id="org.objectweb.asm.analysis" version="8.0.1.v20200420-1007"/>
       <unit id="org.objectweb.asm.util" version="8.0.1.v20200420-1007"/>
+      <unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 
       <!-- required by Fuse Tooling -->
       <unit id="javax.validation" version="1.1.0.v20200505-2127"/>
@@ -127,8 +130,15 @@
       <unit id="org.codehaus.jackson.mapper" version="1.6.0.v20101005-0925"/>
       <unit id="org.json" version="1.0.0.v201011060100"/>
 
-      <!-- required by jgit -->
+      <!-- required by egit/jgit -->
       <unit id="org.assertj" version="3.14.0.v20200120-1926"/>
+      <unit id="javaewah" version="1.1.7.v20200107-0831"/>
+      <unit id="org.bouncycastle.bcpg" version="1.65.0.v20200527-1955"/>
+      <unit id="net.i2p.crypto.eddsa" version="0.3.0.v20181102-1323"/>
+      <unit id="org.apache.sshd.core" version="0.7.0.v201303101611"/>
+      <unit id="org.apache.sshd.osgi" version="2.6.0.v20210201-2003"/>
+      <unit id="org.apache.sshd.sftp" version="2.6.0.v20210201-2003"/>
+      <unit id="org.apache.mina.core" version="2.0.7.v201401071602"/>
 
       <!-- required by jbosstools-common -->
       <unit id="org.apache.commons.exec" version="1.1.0.v201301240602"/>
@@ -171,10 +181,10 @@
 
     <!-- m2e family, not included in SimRel site (or newer versions); see also simrel site below, and Central TP for more -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/m2e/1.17.1.20201207-1112/"/>
-      <unit id="org.eclipse.m2e.feature.feature.group" version="1.17.1.20201207-1112"/>
-      <unit id="org.eclipse.m2e.tests.common" version="1.17.0.20200924-1339"/>
-      <unit id="org.eclipse.m2e.importer" version="1.17.0.20200924-1339"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/m2e/1.17.2.20210219-1922/"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="1.17.2.20210219-1922"/>
+      <unit id="org.eclipse.m2e.tests.common" version="1.17.1.20210115-1536"/>
+      <unit id="org.eclipse.m2e.importer" version="1.17.1.20210115-1536"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>
@@ -201,38 +211,38 @@
 
     <!-- SimRel -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/simrel/20200916-1000-Simrel.2020-09/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/simrel/20210317-1000-Simrel.2021-03-RC2/"/>
 
       <!-- p2.discovery -->
       <unit id="org.eclipse.equinox.p2.discovery" version="1.1.200.v20190611-1008"/>
-      <unit id="org.eclipse.equinox.p2.discovery.compatibility" version="1.1.200.v20190611-1008"/>
-      <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.1.600.v20200705-1016"/>
+      <unit id="org.eclipse.equinox.p2.discovery.compatibility" version="1.2.0.v20200916-1234"/>
+      <unit id="org.eclipse.equinox.p2.ui.discovery" version="1.2.0.v20200916-1234"/>
 
       <!-- ECF -->
-      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.5.700.v20200812-2314"/>
+      <unit id="org.eclipse.ecf.core.feature.feature.group" version="1.5.701.v20201027-0550"/>
       <unit id="org.eclipse.ecf.core.ssl.feature.feature.group" version="1.1.500.v20200812-2314"/>
-      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1400.v20200812-2314"/>
-      <unit id="org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group" version="1.0.600.v20200816-1842"/>
+      <unit id="org.eclipse.ecf.filetransfer.feature.feature.group" version="3.14.1702.v20201025-2315"/>
+      <unit id="org.eclipse.ecf.filetransfer.httpclient45.feature.feature.group" version="1.0.702.v20201025-2303"/>
       <unit id="org.eclipse.ecf.filetransfer.ssl.feature.feature.group" version="1.1.400.v20200812-2314"/>
-      <unit id="org.eclipse.equinox.concurrent" version="1.1.500.v20200106-1437"/>
+      <unit id="org.eclipse.equinox.concurrent" version="1.2.0.v20210202-1157"/>
 
       <!-- EMF, XSD -->
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.23.0.v20200701-0840"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.25.0.v20201231-0738"/>
       <unit id="org.eclipse.emf.codegen.feature.group" version="2.21.0.v20200708-0547"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.20.0.v20200822-0801"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.22.0.v20210114-1734"/>
       <unit id="org.eclipse.emf.databinding.feature.group" version="1.7.0.v20190323-1059"/>
       <unit id="org.eclipse.emf.ecore.edit.feature.group" version="2.14.0.v20190822-1451"/>
       <unit id="org.eclipse.emf.ecore.editor.feature.group" version="2.17.0.v20190528-0725"/>
       <unit id="org.eclipse.emf.ecore.feature.group" version="2.23.0.v20200630-0516"/>
       <unit id="org.eclipse.emf.edit.feature.group" version="2.16.0.v20190920-0401"/>
-      <unit id="org.eclipse.emf.feature.group" version="2.23.0.v20200822-0801"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.25.0.v20210114-1734"/>
       <unit id="org.eclipse.emf.transaction.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.emf.validation.feature.group" version="1.12.2.202008210805"/>
       <unit id="org.eclipse.emf.workspace.feature.group" version="1.12.0.201805140824"/>
       <unit id="org.eclipse.xsd.ecore.converter.feature.group" version="2.12.0.v20200324-0723"/>
       <unit id="org.eclipse.xsd.edit.feature.group" version="2.13.0.v20200723-0820"/>
       <unit id="org.eclipse.xsd.editor.feature.group" version="2.13.0.v20190323-1100"/>
-      <unit id="org.eclipse.xsd.feature.group" version="2.19.0.v20200723-0820"/>
+      <unit id="org.eclipse.xsd.feature.group" version="2.19.0.v20201230-0836"/>
       <unit id="org.eclipse.xsd.mapping.editor.feature.group" version="2.13.0.v20190323-1100"/>
       <unit id="org.eclipse.xsd.mapping.feature.group" version="2.13.0.v20200723-0820"/>
 
@@ -241,31 +251,31 @@
       <unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
 
       <!-- Platform: CVS, JDT, RCP, PDE, Equinox, Help -->
-      <unit id="org.eclipse.cvs.feature.group" version="1.4.1500.v20200902-1800"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
-      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.700.v20200705-1016"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.900.v20200828-0839"/>
-      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.13.0.v20200828-1034"/>
-      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.10.400.v20200803-1656"/>
-      <unit id="org.eclipse.help.feature.group" version="2.3.300.v20200902-1800"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.18.500.v20200902-1800"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.14.500.v20200902-1800"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.17.0.v20200902-1800"/>
-      <unit id="org.eclipse.rcp.feature.group" version="4.17.0.v20200902-1800"/>
+      <unit id="org.eclipse.cvs.feature.group" version="1.4.1700.v20210303-1800"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1100.v20210209-1541"/>
+      <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.800.v20200916-1234"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.1100.v20210227-0235"/>
+      <unit id="org.eclipse.equinox.server.core.feature.group" version="1.14.100.v20210226-1447"/>
+      <unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.10.600.v20210224-2143"/>
+      <unit id="org.eclipse.help.feature.group" version="2.3.500.v20210303-1800"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.18.700.v20210303-1800"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.14.700.v20210303-1800"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.19.0.v20210303-1800"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.19.0.v20210303-1800"/>
 
       <!-- needed for JBoss Central -->
-      <unit id="org.eclipse.compare" version="3.7.1100.v20200611-0145"/>
+      <unit id="org.eclipse.compare" version="3.7.1300.v20210114-0707"/>
       <unit id="org.eclipse.core.filesystem" version="1.7.700.v20200110-1734"/>
-      <unit id="org.eclipse.core.resources" version="3.13.800.v20200706-2152"/>
-      <unit id="org.eclipse.jface" version="3.21.0.v20200821-1458"/>
-      <unit id="org.eclipse.jface.text" version="3.16.400.v20200807-0831"/>
+      <unit id="org.eclipse.core.resources" version="3.14.0.v20210215-0934"/>
+      <unit id="org.eclipse.jface" version="3.22.100.v20210126-0831"/>
+      <unit id="org.eclipse.jface.text" version="3.17.0.v20210213-0904"/>
       <unit id="org.eclipse.team.core" version="3.8.1100.v20200806-0621"/>
-      <unit id="org.eclipse.team.ui" version="3.8.1000.v20200806-0621"/>
-      <unit id="org.eclipse.ui" version="3.118.0.v20200807-0902"/>
-      <unit id="org.eclipse.ui.editors" version="3.13.300.v20200812-2334"/>
-      <unit id="org.eclipse.ui.forms" version="3.10.0.v20200727-0948"/>
-      <unit id="org.eclipse.ui.ide" version="3.17.200.v20200808-0622"/>
-      <unit id="org.eclipse.ui.workbench.texteditor" version="3.15.0.v20200812-2334"/>
+      <unit id="org.eclipse.team.ui" version="3.8.1200.v20210204-1156"/>
+      <unit id="org.eclipse.ui" version="3.119.0.v20210111-1350"/>
+      <unit id="org.eclipse.ui.editors" version="3.14.0.v20210215-0846"/>
+      <unit id="org.eclipse.ui.forms" version="3.11.100.v20210108-1139"/>
+      <unit id="org.eclipse.ui.ide" version="3.18.100.v20210122-1536"/>
+      <unit id="org.eclipse.ui.workbench.texteditor" version="3.16.0.v20210120-0733"/>
 
       <!-- Zest -->
       <unit id="org.eclipse.draw2d.feature.group" version="3.10.100.201606061308"/>
@@ -284,18 +294,16 @@
       <unit id="org.eclipse.graphiti.ui" version="0.17.0.202005151449"/>
       <unit id="org.eclipse.graphiti.ui.capabilities" version="0.17.0.202005151449"/>
 
+      <!-- m2e.wtp -->
+      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.4.20201128-1705"/>
+      <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.4.4.20201128-1705"/>
+      <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.4.4.20201128-1705"/>
+      <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.4.4.20201128-1705"/>
+
       <!-- launchbar -->
+      <unit id="org.eclipse.launchbar.feature.group" version="10.2.0.202012191711"/>
       <unit id="org.eclipse.remote.core" version="4.0.0.201909031456"/>
       <unit id="org.eclipse.remote.ui" version="2.1.1.201909031456"/>
-
-      <!-- m2e.wtp -->
-      <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.4.4.20200220-1005"/>
-      <unit id="org.eclipse.m2e.wtp.jaxrs.feature.feature.group" version="1.4.4.20200220-1005"/>
-      <unit id="org.eclipse.m2e.wtp.jpa.feature.feature.group" version="1.4.4.20200220-1005"/>
-      <unit id="org.eclipse.m2e.wtp.jsf.feature.feature.group" version="1.4.4.20200220-1005"/>
-
-      <!-- launchbar -->
-      <unit id="org.eclipse.launchbar.feature.group" version="10.0.0.202008310315"/>
 
       <!-- mylyn docs / extras -->
       <unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="3.0.38.202008172112"/>
@@ -306,14 +314,14 @@
       <unit id="org.apache.lucene.queryparser" version="6.1.0.v20161115-1612"/>
 
       <!-- egit -->
-      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.jgit.http.apache.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.jgit.ssh.jsch.feature.group" version="5.9.0.202009080501-r"/>
-      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.9.0.202009080501-r"/>
+      <unit id="org.eclipse.egit.mylyn.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.egit.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.jgit.ssh.jsch.feature.group" version="5.11.0.202103091610-r"/>
+      <unit id="org.eclipse.mylyn.github.feature.feature.group" version="5.11.0.202103091610-r"/>
 
       <!-- TM4E required by dockertools and wild web developer-->
       <unit id="org.eclipse.tm4e.registry" version="0.4.0.201911130739"/>
@@ -322,9 +330,9 @@
       <unit id="org.eclipse.tm4e.languageconfiguration" version="0.3.5.202007200903"/>
 
       <!-- required by JDT.LS -->
-      <unit id="org.eclipse.xtend.lib" version="2.23.0.v20200831-0723"/>
-      <unit id="org.eclipse.xtext.xbase.lib" version="2.23.0.v20200831-0723"/>
-      <unit id="org.eclipse.xtend.lib.macro" version="2.23.0.v20200831-0723"/>
+      <unit id="org.eclipse.xtend.lib" version="2.25.0.v20210301-0821"/>
+      <unit id="org.eclipse.xtext.xbase.lib" version="2.25.0.v20210301-0821"/>
+      <unit id="org.eclipse.xtend.lib.macro" version="2.25.0.v20210301-0821"/>
 
     </location>
 
@@ -348,15 +356,15 @@
 
     <!-- Buildship (for sources)-->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/buildship/3.1.4.v20200326-1743/"/>
-      <unit id="org.eclipse.buildship.feature.group" version="3.1.4.v20200326-1743"/>
-      <unit id="org.gradle.toolingapi" version="6.3.0.v20200326-1743"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/buildship/3.1.5.v20210113-0929/"/>
+      <unit id="org.eclipse.buildship.feature.group" version="3.1.5.v20210113-0929"/>
+      <unit id="org.gradle.toolingapi" version="6.8.0.v20210113-0929"/>
     </location>
 
-    <!-- Complete JGit, see https://issues.jboss.org/browse/JBIDE-26815-->
+    <!-- Complete JGit, see https://issues.jboss.org/browse/JBIDE-26815 -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jgit/5.9.0.202009080501-r/"/>
-      <unit id="org.eclipse.jgit.junit" version="5.9.0.202009080501-r"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jgit/5.11.0.202103091610-r/"/>
+      <unit id="org.eclipse.jgit.junit" version="5.11.0.202103091610-r"/>
     </location>
 
     <!-- pull newer mylyn stuff than what's in simrel, so we have the same version as in Nodeclipse. This lets the install test job pass in 
@@ -389,7 +397,7 @@
 
     <!-- DTP -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/dtp/1.14.200.202008192017/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/dtp/1.14.200.202009292210/"/>
       <unit id="org.eclipse.datatools.common.doc.user.feature.group" version="1.14.102.201911250848"/>
       <unit id="org.eclipse.datatools.connectivity.doc.user.feature.group" version="1.14.102.201911250848"/>
       <unit id="org.eclipse.datatools.connectivity.feature.feature.group" version="1.14.102.201911250848"/>
@@ -417,12 +425,12 @@
       <unit id="org.eclipse.datatools.modelbase.feature.feature.group" version="1.14.102.201911250848"/>
       <unit id="org.eclipse.datatools.sqldevtools.data.feature.feature.group" version="1.14.200.202008192017"/>
       <unit id="org.eclipse.datatools.sqldevtools.ddl.feature.feature.group" version="1.14.102.201911250848"/>
-      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.14.200.202008192017"/>
-      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.14.200.202008192017"/>
+      <unit id="org.eclipse.datatools.sqldevtools.ddlgen.feature.feature.group" version="1.14.200.202009292210"/>
+      <unit id="org.eclipse.datatools.sqldevtools.feature.feature.group" version="1.14.200.202009292210"/>
       <unit id="org.eclipse.datatools.sqldevtools.parsers.feature.feature.group" version="1.14.102.201911250848"/>
       <unit id="org.eclipse.datatools.sqldevtools.results.feature.feature.group" version="1.14.200.202008192017"/>
       <unit id="org.eclipse.datatools.sqldevtools.schemaobjecteditor.feature.feature.group" version="1.14.102.201911250848"/>
-      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.14.200.202008192017"/>
+      <unit id="org.eclipse.datatools.sqldevtools.sqlbuilder.feature.feature.group" version="1.14.200.202009292210"/>
       <unit id="org.eclipse.datatools.sqltools.doc.user.feature.group" version="1.14.102.201911250848"/>
     </location>
 
@@ -434,104 +442,104 @@
 
     <!-- RSE -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/tm/4.5.200.201901312252/"/>
-      <unit id="org.eclipse.rse.terminals.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.connectorservice.ssh" version="4.5.100.201901312252"/>
-      <unit id="org.eclipse.rse.core" version="4.5.100.201901312252"/>
-      <unit id="org.eclipse.rse.services" version="4.5.100.201901312252"/>
-      <unit id="org.eclipse.rse.services.ssh" version="4.5.100.201901312252"/>
-      <unit id="org.eclipse.rse.ui" version="4.5.100.201901312252"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/tm/4.5.300.202101081641/"/>
+      <unit id="org.eclipse.rse.terminals.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.connectorservice.ssh" version="4.5.300.202101081027"/>
+      <unit id="org.eclipse.rse.core" version="4.5.300.202101081027"/>
+      <unit id="org.eclipse.rse.services" version="4.5.300.202101081027"/>
+      <unit id="org.eclipse.rse.services.ssh" version="4.5.300.202101081027"/>
+      <unit id="org.eclipse.rse.ui" version="4.5.300.202101081027"/>
 
-      <unit id="org.eclipse.rse.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.ftp.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.local.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.ssh.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.telnet.feature.group" version="4.5.100.202002061858"/>
-      <unit id="org.eclipse.rse.useractions.feature.group" version="4.5.100.202002061858"/>
+      <unit id="org.eclipse.rse.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.ftp.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.local.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.ssh.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.telnet.feature.group" version="4.5.300.202101081641"/>
+      <unit id="org.eclipse.rse.useractions.feature.group" version="4.5.300.202101081641"/>
 
-      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.5.100.201901312304"/>
+      <unit id="org.eclipse.tm.terminal.view.ui.rse" version="4.5.300.202101081027"/>
     </location>
 
     <!-- TM is now part of CDT-->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/cdt/10.0.0/"/>
-      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="10.0.0.202008310315"/>
-      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="10.0.0.202008310315"/>
-      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="10.0.0.202008310315"/>
-      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="10.0.0.202009071350"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/cdt/10.2.0-rc2/"/>
+      <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="10.2.0.202012191711"/>
+      <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="10.2.0.202012191711"/>
+      <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="10.2.0.202012191711"/>
+      <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="10.2.0.202103012351"/>
       <unit id="org.eclipse.tm.terminal.view.core" version="4.7.0.202008310315"/>
-      <unit id="org.eclipse.tm.terminal.view.ui" version="4.7.0.202008310315"/>
-      <unit id="org.eclipse.cdt.native.feature.group" version="10.0.0.202009030027"/>
+      <unit id="org.eclipse.tm.terminal.view.ui" version="4.8.0.202103012351"/>
+      <unit id="org.eclipse.cdt.native.feature.group" version="10.2.0.202102030214"/>
     </location>
 
     <!-- Jetty 9 -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.31.v20200723/"/>
-      <unit id="org.eclipse.jetty.client" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.continuation" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.http" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.io" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.proxy" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.rewrite" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.security" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.server" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.servlets" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.util" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.webapp" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.websocket.api" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.websocket.client" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.websocket.common" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.31.v20200723"/>
-      <unit id="org.eclipse.jetty.xml" version="9.4.31.v20200723"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jetty/9.4.37.v20210219/"/>
+      <unit id="org.eclipse.jetty.client" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.continuation" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.http" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.io" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.proxy" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.rewrite" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.security" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.server" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.servlet" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.servlets" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.util" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.webapp" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.websocket.api" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.websocket.client" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.websocket.common" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.websocket.server" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.websocket.servlet" version="9.4.37.v20210219"/>
+      <unit id="org.eclipse.jetty.xml" version="9.4.37.v20210219"/>
     </location>
 
     <!-- Web Tools -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/webtools/R-3.19.0-20200828030223/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/webtools/S-3.21.0.RC2-20210304100654/"/>
       <unit id="org.eclipse.jem" version="2.0.600.v201903222024"/>
       <unit id="org.eclipse.jem.beaninfo" version="2.0.300.v201903222024"/>
-      <unit id="org.eclipse.jem.beaninfo.vm" version="2.0.300.v201903222024"/>
-      <unit id="org.eclipse.jem.beaninfo.vm.common" version="2.0.300.v201903222024"/>
-      <unit id="org.eclipse.jem.proxy" version="2.0.500.v201903222024"/>
+      <unit id="org.eclipse.jem.beaninfo.vm" version="2.1.0.v202101081429"/>
+      <unit id="org.eclipse.jem.beaninfo.vm.common" version="2.1.0.v202101081429"/>
+      <unit id="org.eclipse.jem.proxy" version="2.1.0.v202101081429"/>
       <unit id="org.eclipse.jem.util" version="2.1.202.v202007142017"/>
-      <unit id="org.eclipse.jem.workbench" version="2.0.400.v201903222024"/>
+      <unit id="org.eclipse.jem.workbench" version="2.1.0.v202101081429"/>
       <unit id="org.eclipse.jpt.common.eclipselink.feature.feature.group" version="1.3.200.v201903221940"/>
       <unit id="org.eclipse.jpt.common.feature.feature.group" version="1.5.100.v201903221940"/>
       <unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.5.200.v202007091849"/>
       <unit id="org.eclipse.jpt.jpa.eclipselink.feature.feature.group" version="3.4.101.v201903221940"/>
-      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.6.1.v202007091901"/>
+      <unit id="org.eclipse.jpt.jpa.feature.feature.group" version="3.6.1.v202102130825"/>
       <unit id="org.eclipse.jsf.feature.feature.group" version="3.10.1.v202007170344"/>
       <unit id="org.eclipse.jst.common.annotations.controller" version="1.1.300.v201903222024"/>
       <unit id="org.eclipse.jst.common.annotations.core" version="1.1.300.v201903222024"/>
       <unit id="org.eclipse.jst.common.annotations.ui" version="1.1.300.v202007170603"/>
-      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.13.1.v202007161535"/>
+      <unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.21.0.v202101040919"/>
       <unit id="org.eclipse.jst.common.frameworks" version="1.1.701.v201903222024"/>
       <unit id="org.eclipse.jst.common.ui" version="1.0.301.v201903222024"/>
       <unit id="org.eclipse.jst.ejb.doc.user" version="1.1.301.v201903222024"/>
       <unit id="org.eclipse.jst.ejb.ui" version="1.1.911.v201903222024"/>
       <unit id="org.eclipse.jst.ejb.ui.infopop" version="1.0.300.v201903222024"/>
-      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.19.0.v202007100056"/>
-      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.19.0.v202007100056"/>
+      <unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.21.0.v202012212201"/>
+      <unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.21.0.v202012212201"/>
       <unit id="org.eclipse.jst.enterprise_userdoc.feature.feature.group" version="3.6.100.v201908261515"/>
-      <unit id="org.eclipse.jst.j2ee" version="1.2.400.v202007011329"/>
-      <unit id="org.eclipse.jst.j2ee.core" version="1.4.2.v202007170603"/>
-      <unit id="org.eclipse.jst.j2ee.doc.user" version="1.1.400.v201903222024"/>
+      <unit id="org.eclipse.jst.j2ee" version="1.2.500.v202101072335"/>
+      <unit id="org.eclipse.jst.j2ee.core" version="1.4.3.v202101042017"/>
+      <unit id="org.eclipse.jst.j2ee.doc.user" version="1.1.400.v202101072335"/>
       <unit id="org.eclipse.jst.j2ee.ejb" version="1.1.901.v201903222024"/>
       <unit id="org.eclipse.jst.j2ee.ejb.annotation.model" version="1.1.500.v201910291429"/>
       <unit id="org.eclipse.jst.j2ee.ejb.annotations.emitter" version="1.1.300.v201903222024"/>
-      <unit id="org.eclipse.jst.j2ee.ejb.annotations.ui" version="1.1.400.v201910291429"/>
+      <unit id="org.eclipse.jst.j2ee.ejb.annotations.ui" version="1.2.0.v202101081429"/>
       <unit id="org.eclipse.jst.j2ee.ejb.annotations.xdoclet" version="1.2.300.v201903222024"/>
       <unit id="org.eclipse.jst.j2ee.infopop" version="1.0.300.v201903222024"/>
       <unit id="org.eclipse.jst.j2ee.jca" version="1.1.1000.v201904091346"/>
       <unit id="org.eclipse.jst.j2ee.jca.ui" version="1.1.601.v201904091346"/>
       <unit id="org.eclipse.jst.j2ee.navigator.ui" version="1.1.800.v202007170603"/>
       <unit id="org.eclipse.jst.j2ee.ui" version="1.1.931.v202007170603"/>
-      <unit id="org.eclipse.jst.j2ee.web" version="1.1.911.v201903222025"/>
+      <unit id="org.eclipse.jst.j2ee.web" version="1.1.1000.v202102050432"/>
       <unit id="org.eclipse.jst.j2ee.webservice" version="1.1.700.v201904091346"/>
       <unit id="org.eclipse.jst.j2ee.webservice.ui" version="1.1.700.v201903222025"/>
-      <unit id="org.eclipse.jst.j2ee.xdoclet.runtime" version="1.1.300.v201903222025"/>
+      <unit id="org.eclipse.jst.j2ee.xdoclet.runtime" version="1.2.0.v202101081429"/>
       <unit id="org.eclipse.jst.jee" version="1.0.902.v201905281719"/>
       <unit id="org.eclipse.jst.jee.ejb" version="1.0.500.v201903222025"/>
       <unit id="org.eclipse.jst.jee.ui" version="1.0.901.v201903222025"/>
@@ -540,20 +548,20 @@
       <unit id="org.eclipse.jst.jsf.common" version="1.5.103.v201902121810"/>
       <unit id="org.eclipse.jst.jsf.core" version="1.8.2.v202007170344"/>
       <unit id="org.eclipse.jst.jsf.doc.user" version="1.5.0.v201902121810"/>
-      <unit id="org.eclipse.jst.jsp.core" version="1.3.0.v202005192134"/>
-      <unit id="org.eclipse.jst.jsp.ui" version="1.3.0.v202008120247"/>
+      <unit id="org.eclipse.jst.jsp.core" version="1.4.0.v202103040444"/>
+      <unit id="org.eclipse.jst.jsp.ui" version="1.3.200.v202102222242"/>
       <unit id="org.eclipse.jst.jsp.ui.infopop" version="1.0.200.v201903222120"/>
       <unit id="org.eclipse.jst.pagedesigner" version="1.8.4.v202007170344"/>
-      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.3.800.v202008171926"/>
+      <unit id="org.eclipse.jst.server_adapters.ext.feature.feature.group" version="3.4.100.v202102111918"/>
       <unit id="org.eclipse.jst.server_adapters.feature.feature.group" version="3.2.600.v202007170127"/>
-      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.400.v202007170127"/>
+      <unit id="org.eclipse.jst.server_core.feature.feature.group" version="3.4.400.v202011161356"/>
       <unit id="org.eclipse.jst.server_ui.feature.feature.group" version="3.4.400.v202007170127"/>
       <unit id="org.eclipse.jst.server_userdoc.feature.feature.group" version="3.3.300.v201901310132"/>
-      <unit id="org.eclipse.jst.servlet.ui" version="1.1.921.v201903222025"/>
+      <unit id="org.eclipse.jst.servlet.ui" version="1.1.1000.v202101042017"/>
       <unit id="org.eclipse.jst.servlet.ui.infopop" version="1.0.500.v201903222024"/>
-      <unit id="org.eclipse.jst.standard.schemas" version="1.2.300.v201903222120"/>
-      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.19.0.v202007072012"/>
-      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.19.0.v202008250115"/>
+      <unit id="org.eclipse.jst.standard.schemas" version="1.2.400.v202101070609"/>
+      <unit id="org.eclipse.jst.web_core.feature.feature.group" version="3.21.0.v202101130222"/>
+      <unit id="org.eclipse.jst.web_ui.feature.feature.group" version="3.21.0.v202101180039"/>
       <unit id="org.eclipse.jst.web_userdoc.feature.feature.group" version="3.6.1.v201908261515"/>
       <unit id="org.eclipse.jst.webpageeditor.feature.feature.group" version="2.9.1.v202007170344"/>
       <unit id="org.eclipse.jst.ws" version="1.0.900.v201910301957"/>
@@ -569,13 +577,13 @@
       <unit id="org.eclipse.jst.ws.consumption.ui.doc.user" version="1.0.700.v201903222115"/>
       <unit id="org.eclipse.jst.ws.creation.ejb.ui" version="1.0.300.v201910301957"/>
       <unit id="org.eclipse.jst.ws.creation.ui" version="1.0.1000.v201910301957"/>
-      <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.600.v202004091240"/>
+      <unit id="org.eclipse.jst.ws.cxf.feature.feature.group" version="1.1.700.v202011292043"/>
       <unit id="org.eclipse.jst.ws.doc.user" version="1.0.700.v201903222115"/>
       <unit id="org.eclipse.jst.ws.infopop" version="1.0.400.v201903050508"/>
-      <unit id="org.eclipse.jst.ws.jaxrs.core" version="1.0.850.v201903050508"/>
+      <unit id="org.eclipse.jst.ws.jaxrs.core" version="1.0.851.v202101130222"/>
       <unit id="org.eclipse.jst.ws.jaxrs.ui" version="1.0.801.v201906251834"/>
       <unit id="org.eclipse.jst.ws.jaxws.dom.feature.feature.group" version="1.0.303.v201909051708"/>
-      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.600.v202008101342"/>
+      <unit id="org.eclipse.jst.ws.jaxws.feature.feature.group" version="1.2.700.v202011292043"/>
       <unit id="org.eclipse.jst.ws.jaxws_userdoc.feature.feature.group" version="1.0.403.v201909051708"/>
       <unit id="org.eclipse.jst.ws.uddiregistry" version="1.1.0.v201910301957"/>
       <unit id="org.eclipse.jst.ws.ui" version="1.1.0.v201910301957"/>
@@ -583,44 +591,44 @@
       <unit id="org.eclipse.wst.command.env.ui" version="1.2.0.v201910301957"/>
       <unit id="org.eclipse.wst.common.fproj.feature.group" version="3.7.3.v202007142017"/>
       <unit id="org.eclipse.wst.common.project.facet.core" version="1.4.401.v202007142017"/>
-      <unit id="org.eclipse.wst.common_core.feature.feature.group" version="3.19.0.v202007161535"/>
-      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.19.0.v202007161535"/>
+      <unit id="org.eclipse.wst.common_core.feature.feature.group" version="3.21.0.v202101070357"/>
+      <unit id="org.eclipse.wst.common_ui.feature.feature.group" version="3.21.0.v202101112327"/>
       <unit id="org.eclipse.wst.jsdt.chromium.debug.feature.feature.group" version="0.6.100.v201908270117"/>
       <unit id="org.eclipse.wst.jsdt.debug.rhino.ui" version="1.0.600.v202001081921"/>
-      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.3.100.v202008161908"/>
-      <unit id="org.eclipse.wst.jsdt.web.support.jsp" version="1.1.100.v202008250115"/>
+      <unit id="org.eclipse.wst.jsdt.feature.feature.group" version="2.3.400.v202102101628"/>
+      <unit id="org.eclipse.wst.jsdt.web.support.jsp" version="1.1.101.v202101180039"/>
       <unit id="org.eclipse.wst.json_core.feature.feature.group" version="1.1.8.v201909302219"/>
-      <unit id="org.eclipse.wst.json_ui.feature.feature.group" version="1.1.8.v202004230532"/>
-      <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.801.v202007170127"/>
-      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.800.v202007170127"/>
-      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.900.v202007170127"/>
+      <unit id="org.eclipse.wst.json_ui.feature.feature.group" version="1.1.9.v202101100033"/>
+      <unit id="org.eclipse.wst.server_adapters.feature.feature.group" version="3.2.801.v202101040859"/>
+      <unit id="org.eclipse.wst.server_core.feature.feature.group" version="3.3.900.v202102111918"/>
+      <unit id="org.eclipse.wst.server_ui.feature.feature.group" version="3.3.1000.v202101040859"/>
       <unit id="org.eclipse.wst.server_userdoc.feature.feature.group" version="3.3.300.v201901310132"/>
-      <unit id="org.eclipse.wst.sse.core" version="1.2.500.v202008090735"/>
-      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.19.0.v202008180353"/>
-      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.19.0.v202008242027"/>
+      <unit id="org.eclipse.wst.sse.core" version="1.2.600.v202102110535"/>
+      <unit id="org.eclipse.wst.web_core.feature.feature.group" version="3.21.0.v202102251419"/>
+      <unit id="org.eclipse.wst.web_ui.feature.feature.group" version="3.21.0.v202102251419"/>
       <unit id="org.eclipse.wst.web_userdoc.feature.feature.group" version="3.18.0.v202004271556"/>
       <unit id="org.eclipse.wst.ws.explorer" version="1.0.1100.v202007222105"/>
       <unit id="org.eclipse.wst.ws.infopop" version="1.0.400.v201903050508"/>
       <unit id="org.eclipse.wst.ws.service.policy.ui" version="1.0.500.v201903050508"/>
       <unit id="org.eclipse.wst.ws.ui" version="1.2.0.v201910301957"/>
-      <unit id="org.eclipse.wst.ws_core.feature.feature.group" version="3.8.0.v202007222105"/>
+      <unit id="org.eclipse.wst.ws_core.feature.feature.group" version="3.21.0.v202101270311"/>
       <unit id="org.eclipse.wst.ws_ui.feature.feature.group" version="3.9.100.v202004082157"/>
       <unit id="org.eclipse.wst.ws_userdoc.feature.feature.group" version="3.1.501.v201909051708"/>
       <unit id="org.eclipse.wst.wsdl.ui" version="1.3.100.v202004082216"/>
       <unit id="org.eclipse.wst.wsi.ui" version="1.1.100.v202007221938"/>
       <unit id="org.eclipse.wst.xml.xpath2.processor.feature.feature.group" version="2.0.302.v201909031400"/>
-      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.19.0.v202008180353"/>
-      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.19.0.v202008192217"/>
+      <unit id="org.eclipse.wst.xml_core.feature.feature.group" version="3.21.0.v202102251419"/>
+      <unit id="org.eclipse.wst.xml_ui.feature.feature.group" version="3.21.0.v202102222242"/>
       <unit id="org.eclipse.wst.xml_userdoc.feature.feature.group" version="3.18.0.v202004271556"/>
       <unit id="org.eclipse.wst.xsl.feature.feature.group" version="1.3.900.v202005251734"/>
     </location>
 
     <!-- Eclipse Docker Tooling (see Orbit section above for dependencies) -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/5.0.0.202009091443/"/>
-      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="5.0.0.202009091443"/>
-      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="5.0.0.202009091443"/>
-      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="5.0.0.202009091443"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/docker/5.2.0.202103091924/"/>
+      <unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="5.2.0.202103091924"/>
+      <unit id="org.eclipse.linuxtools.vagrant.feature.feature.group" version="5.2.0.202103091924"/>
+      <unit id="org.eclipse.linuxtools.docker.tests.feature.feature.group" version="5.2.0.202103091924"/>
     </location>
 
     <!-- SWT Bot -->
@@ -635,43 +643,44 @@
 
     <!-- Reddeer -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/reddeer/3.2.0/"/>
-      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="3.2.0.v20201209-2101"/>
-      <unit id="org.eclipse.reddeer.jdt.junit" version="3.2.0.v20201209-2101"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/reddeer/3.3.0.RC2/"/>
+      <unit id="org.eclipse.reddeer.codegen.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.eclipse.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.gef.spy.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.graphiti.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.logparser.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.recorder.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.spy.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.swt.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.tests.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.ui.feature.feature.group" version="3.3.0.v20210310-1951"/>
+      <unit id="org.eclipse.reddeer.jdt.junit" version="3.3.0.v20210310-1951"/>
     </location>
 
     <!-- LSP4E -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.17.0/"/>
-      <unit id="org.eclipse.lsp4e" version="0.13.4.202011121435"/>
-      <unit id="org.eclipse.lsp4e.debug" version="0.12.2.202011091956"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4e/0.18.0/"/>
+      <unit id="org.eclipse.lsp4e" version="0.13.5.202103011336"/>
+      <unit id="org.eclipse.lsp4e.debug" version="0.12.3.202102121348"/>
       <unit id="org.eclipse.lsp4j" version="0.10.0.v20201105-1103"/>
       <unit id="org.eclipse.lsp4j.debug" version="0.10.0.v20201105-1103"/>
       <unit id="org.eclipse.lsp4j.jsonrpc" version="0.10.0.v20201105-1103"/>
       <unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.10.0.v20201105-1103"/>
+      <unit id="org.eclipse.lsp4e.jdt" version="0.10.1.202009250956"/>
     </location>
 
     <!-- LSP4MP -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4mp/0.1.0/"/>
-      <unit id="org.eclipse.lsp4mp.jdt.core" version="0.1.0"/>
-      <unit id="org.eclipse.lsp4mp.jdt.test" version="0.1.0"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/lsp4mp/0.2.0.20210121-0809/"/>
+      <unit id="org.eclipse.lsp4mp.jdt.core" version="0.2.0.20210121-0809"/>
+      <unit id="org.eclipse.lsp4mp.jdt.test" version="0.2.0.20210121-0809"/>
     </location>
 
     <!-- JDT LS -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jdtls/0.61.0.202009152130/"/>
-      <unit id="org.eclipse.jdt.ls.core" version="0.61.0.202009152130"/>
-      <unit id="org.eclipse.jdt.ls.tests" version="0.61.0.202009152130"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/jdtls/0.69.0.202102120513/"/>
+      <unit id="org.eclipse.jdt.ls.core" version="0.69.0.202102120513"/>
+      <unit id="org.eclipse.jdt.ls.tests" version="0.69.0.202102120513"/>
     </location>
 
     <!-- Microprofile -->
@@ -697,8 +706,8 @@
 
     <!-- JBIDE-25979 Apache Camel Language Server -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.202101051524/"/>
-      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.202101051524"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/camel-lsp-client/1.0.0.202102041653/"/>
+      <unit id="com.github.cameltooling.lsp.eclipse.client.feature.feature.group" version="1.0.0.202102041653"/>
     </location>
 
     <!-- JBDS-4807 m2e-chromatic -->
@@ -710,17 +719,23 @@
 
     <!-- Wild Web Developer -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/wildwebdeveloper/0.11.4/"/>
-      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.10.5.202012011111"/>
-      <unit id="org.eclipse.wildwebdeveloper.embedder.node" version="0.2.1.202011222154"/>
-      <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.10.3.202011132012"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/wildwebdeveloper/0.11.5/"/>
+      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.10.6.202102181620"/>
+      <unit id="org.eclipse.wildwebdeveloper.embedder.node" version="0.2.2.202102092209"/>
+      <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="0.10.4.202102250843"/>
     </location>
 
-    <!-- JDK15 support for JDT 4.17 (https://marketplace.eclipse.org/content/java-15-support-eclipse-2020-09-417) -->
+    <!-- JDK16 support for JDT 4.19 (https://marketplace.eclipse.org/content/java-16-support-eclipse-2021-03-419) -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/eclipse/4.17.JAVA15_PATCH/"/>
-      <unit id="org.eclipse.jdt.java15patch.feature.group" version="1.2.0.v20201001-0636_JAVA15_PATCH"/>
-      <unit id="org.eclipse.pde.java15patch.feature.group" version="1.2.0.v20200915-0627_JAVA15_PATCH"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/eclipse/4.19.JAVA16_PATCH-20210305-0350/"/>
+      <unit id="org.eclipse.jdt.java16patch.feature.group" version="1.2.100.v20210305-0753_BETA_JAVA16"/>
+      <unit id="org.eclipse.pde.java16patch.feature.group" version="1.2.100.v20210305-0753_BETA_JAVA16"/>
+    </location>
+
+    <!-- eclipse base for tests bundles -->
+    <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/eclipse/I20210303-1800-RC2/"/>
+      <unit id="org.eclipse.ui.tests.harness" version="1.8.0.v20210111-1217"/>
     </location>
 
   </locations>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -45,6 +45,7 @@
 							<failOnError>${validate-target-platform.failOnError}</failOnError>
 							<checkDependencies>true</checkDependencies>
 							<checkProvisioning>true</checkProvisioning>
+							<executionEnvironment>JavaSE-11</executionEnvironment>
 						</configuration>
 					</execution>
 				</executions>

--- a/jbosstools/multiple/pom.xml
+++ b/jbosstools/multiple/pom.xml
@@ -15,7 +15,7 @@
 		<!-- set this to false to allow validation to proceed but NOT fail the build -->
 		<validate-target-platform.failOnError>true</validate-target-platform.failOnError>
 		<!-- JBIDE-23481, JBDS-4440 include 3rd party sources in the target platforms-->
-		<mirror-target-to-repo.includeSources>true</mirror-target-to-repo.includeSources>
+		<mirror-target-to-repo.includeSources>false</mirror-target-to-repo.includeSources>
 		<!-- JBIDE-25228, JBIDE-25220 explicitly set options for mirroring -->
 		<mirror-target-to-repo.followStrictOnly>true</mirror-target-to-repo.followStrictOnly>
 		<mirror-target-to-repo.followOnlyFilteredRequirements>false</mirror-target-to-repo.followOnlyFilteredRequirements>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tychoVersion>1.7.0</tychoVersion>
+		<tychoVersion>2.3.0-SNAPSHOT</tychoVersion>
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
-		<jbossTychoPluginsVersion>1.7.0</jbossTychoPluginsVersion>
+		<jbossTychoPluginsVersion>2.2.0</jbossTychoPluginsVersion>
 		<!-- if https://issues.jboss.org/browse/JBIDE-22248 comes back, use <jbossNexus>origin-repository.jboss.org</jbossNexus> -->
 		<jbossNexus>repository.jboss.org</jbossNexus>
 		<!-- JBIDE-21120 when deploying a non-SNAPSHOT, override these values in Jenkins or via commandline using values in distributionManagement below -->


### PR DESCRIPTION
simrel 20210317-1000-Simrel.2021-03-RC2
eclipse 4.19.JAVA16_PATCH-20210305-0350
wildwebdeveloper 0.11.5
camel-lsp-client 1.0.0.202102041653
jdtls 0.69.0.202102120513
lsp4e 0.18.0
lsp4mp 0.2.0.20210121-0809
reddeer 3.3.0.RC2
docker 5.2.0.202103091924
webtools S-3.21.0.RC2-20210304100654
jetty 9.4.37.v20210219
cdt 10.2.0-rc2
tm 4.5.300.202101081641
dtp 1.14.200.202009292210
buildship 3.1.5.v20210113-0929
eclipse I20210303-1800-RC2
m2e 1.17.2.20210219-1922
jgit 5.11.0.202103091610-r
orbit R20210223232630
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>